### PR TITLE
[CORE-5319] Auto retry on replication failure

### DIFF
--- a/coordinator/src/main/resources/reference.conf
+++ b/coordinator/src/main/resources/reference.conf
@@ -91,10 +91,10 @@ com.socrata.coordinator.secondary-watcher = ${com.socrata.coordinator.common} {
   database.tcp-keep-alive = true
 
   # max-retries of 1 means secondary watcher will retry after an error at most 1 more time
-  max-retries = 3
+  max-retries = 6
 
   # base interval for exponential backoff.  Backoff = <backoff-interval> * 2^(retry#)
-  backoff-interval = 1 minute
+  backoff-interval = 5 minutes
 
   tmpdir = ${java.io.tmpdir}
 }

--- a/coordinator/src/main/resources/reference.conf
+++ b/coordinator/src/main/resources/reference.conf
@@ -90,5 +90,11 @@ com.socrata.coordinator.secondary-watcher = ${com.socrata.coordinator.common} {
   database.app-name = "secondary-watcher"
   database.tcp-keep-alive = true
 
+  # max-retries of 1 means secondary watcher will retry after an error at most 1 more time
+  max-retries = 3
+
+  # base interval for exponential backoff.  Backoff = <backoff-interval> * 2^(retry#)
+  backoff-interval = 1 minute
+
   tmpdir = ${java.io.tmpdir}
 }

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/common/SoQLCommon.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/common/SoQLCommon.scala
@@ -1,28 +1,28 @@
 package com.socrata.datacoordinator.common
 
-import com.socrata.datacoordinator.{Row, MutableRow}
-import com.socrata.datacoordinator.service.{SchemaFinder, MutatorCommon}
-import com.socrata.soql.types._
-import com.socrata.soql.environment.{ColumnName, TypeName}
-import com.socrata.soql.brita.{AsciiIdentifierFilter, IdentifierFilter}
-import com.socrata.datacoordinator.common.soql.{SoQLRowLogCodec, SoQLRep, SoQLTypeContext}
-import com.socrata.datacoordinator.truth.metadata.{DatasetCopyContext, DatasetInfo, AbstractColumnInfoLike, ColumnInfo}
-import com.socrata.datacoordinator.truth.json.{JsonColumnWriteRep, JsonColumnRep, JsonColumnReadRep}
-import java.util.concurrent.ExecutorService
-import com.socrata.datacoordinator.truth.universe.sql.{PostgresUniverse, PostgresCommonSupport}
-import org.joda.time.DateTime
-import com.socrata.datacoordinator.util.collection.{MutableColumnIdSet, UserColumnIdMap, ColumnIdSet, ColumnIdMap}
-import com.socrata.datacoordinator.truth.loader.RowPreparer
-import com.socrata.datacoordinator.id.{UserColumnId, DatasetId, RowVersion, RowId}
-import java.sql.Connection
-import java.io.{File, OutputStream, Reader}
-import com.socrata.datacoordinator.util.{NullCache, Cache, TransferrableContextTimingReport}
-import javax.sql.DataSource
 import com.rojoma.simplearm.{SimpleArm, Managed}
-import com.socrata.soql.types.obfuscation.{Quadifier, CryptProvider}
-import scala.concurrent.duration.{FiniteDuration, Duration}
-import java.security.SecureRandom
+import com.socrata.datacoordinator.common.soql.{SoQLRowLogCodec, SoQLRep, SoQLTypeContext}
+import com.socrata.datacoordinator.id.{UserColumnId, DatasetId, RowVersion, RowId}
+import com.socrata.datacoordinator.service.{SchemaFinder, MutatorCommon}
+import com.socrata.datacoordinator.truth.json.{JsonColumnWriteRep, JsonColumnRep, JsonColumnReadRep}
+import com.socrata.datacoordinator.truth.loader.RowPreparer
+import com.socrata.datacoordinator.truth.metadata.{DatasetCopyContext, DatasetInfo, AbstractColumnInfoLike, ColumnInfo}
+import com.socrata.datacoordinator.truth.universe.sql.{PostgresUniverse, PostgresCommonSupport}
 import com.socrata.datacoordinator.truth.universe.{SchemaFinderProvider, CacheProvider}
+import com.socrata.datacoordinator.util.collection.{MutableColumnIdSet, UserColumnIdMap, ColumnIdSet, ColumnIdMap}
+import com.socrata.datacoordinator.util.{NullCache, Cache, TransferrableContextTimingReport}
+import com.socrata.datacoordinator.{Row, MutableRow}
+import com.socrata.soql.brita.{AsciiIdentifierFilter, IdentifierFilter}
+import com.socrata.soql.environment.{ColumnName, TypeName}
+import com.socrata.soql.types._
+import com.socrata.soql.types.obfuscation.{Quadifier, CryptProvider}
+import java.io.{File, OutputStream, Reader}
+import java.security.SecureRandom
+import java.sql.Connection
+import java.util.concurrent.ExecutorService
+import javax.sql.DataSource
+import org.joda.time.DateTime
+import scala.concurrent.duration.{FiniteDuration, Duration}
 
 object SoQLSystemColumns { sc =>
   val id = new UserColumnId(":id")

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
@@ -15,5 +15,7 @@ class SecondaryWatcherConfig(config: Config, root: String) {
   val metrics = config.getConfig(k("metrics"))
   val watcherId = UUID.fromString(config.getString(k("watcher-id")))
   val claimTimeout = config.getDuration(k("claim-timeout"), MILLISECONDS).longValue.millis
+  val maxRetries = config.getInt(k("max-retries"))
+  val backoffInterval = config.getDuration(k("backoff-interval"), MILLISECONDS).longValue.millis
   val tmpdir = new java.io.File(config.getString(k("tmpdir"))).getAbsoluteFile
 }

--- a/coordinator/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
+++ b/coordinator/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
@@ -18,6 +18,9 @@ import com.socrata.datacoordinator.truth.metadata.{LifecycleStage => LS}
 import com.socrata.datacoordinator.util._
 
 class SecondaryWatcherTest extends FunSuite with MustMatchers with MockFactory {
+
+  Class.forName("org.h2.Driver") // force driver to load
+
   val ds = new JdbcDataSource
   ds.setURL("jdbc:h2:mem:")
 

--- a/coordinator/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
+++ b/coordinator/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
@@ -47,7 +47,7 @@ class SecondaryWatcherTest extends FunSuite with MustMatchers with MockFactory {
     val testManifest = mock[SecondaryManifest]
 
     val w = new SecondaryWatcher(common.universe, watcherId, claimTimeout, 10.seconds, 2, common.timingReport) {
-      override protected def getManifest(u: Universe[common.CT, common.CV] with
+      override protected def manifest(u: Universe[common.CT, common.CV] with
                                          SecondaryManifestProvider with PlaybackToSecondaryProvider):
         SecondaryManifest = testManifest
     }
@@ -78,7 +78,7 @@ class SecondaryWatcherTest extends FunSuite with MustMatchers with MockFactory {
     val testManifest = mock[SecondaryManifest]
 
     val w = new SecondaryWatcher(common.universe, watcherId, claimTimeout, 10.seconds, 2, common.timingReport) {
-      override protected def getManifest(u: Universe[common.CT, common.CV] with
+      override protected def manifest(u: Universe[common.CT, common.CV] with
                                          SecondaryManifestProvider with PlaybackToSecondaryProvider):
         SecondaryManifest = testManifest
     }

--- a/coordinator/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
+++ b/coordinator/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
@@ -1,0 +1,78 @@
+package com.socrata.datacoordinator.secondary
+
+import com.rojoma.simplearm.util._
+import java.io.OutputStream
+import java.sql.Connection
+import java.util.concurrent.{Executors, TimeUnit}
+import java.util.UUID
+import org.h2.jdbcx.JdbcDataSource
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{MustMatchers, FunSuite}
+import org.slf4j.LoggerFactory
+import scala.concurrent.duration._
+
+import com.socrata.datacoordinator.common.SoQLCommon
+import com.socrata.datacoordinator.id.DatasetId
+import com.socrata.datacoordinator.truth.universe._
+import com.socrata.datacoordinator.truth.metadata.{LifecycleStage => LS}
+import com.socrata.datacoordinator.util._
+
+class SecondaryWatcherTest extends FunSuite with MustMatchers with MockFactory {
+  val ds = new JdbcDataSource
+  ds.setURL("jdbc:h2:mem:")
+
+  val executor = Executors.newCachedThreadPool()
+  val log = LoggerFactory.getLogger(getClass)
+  val watcherId = UUID.fromString("61e9a209-98e7-4daa-9c43-5778a96e1d8a")
+  val claimTimeout = (10 * 1000).millis
+  val testStoreId = "testpg"
+  def dummyCopyIn(c: Connection, s: String, f: OutputStream => Unit): Long = 0L
+
+  val common = new SoQLCommon(
+    ds,
+    dummyCopyIn,
+    executor,
+    _ => None,
+    new LoggedTimingReport(log) with StackedTimingReport with MetricsTimingReport with TaggableTimingReport,
+    allowDdlOnPublishedCopies = false, // don't care,
+    Duration.fromNanos(1L), // don't care
+    "primus-test",
+    new java.io.File(System.getProperty("java.io.tmpdir")).getAbsoluteFile,
+    Duration.fromNanos(1L), // don't care
+    Duration.fromNanos(1L), // don't care
+    NullCache
+  )
+
+  test("dataset marked broken on error") {
+    val testManifest = mock[SecondaryManifest]
+
+    val w = new SecondaryWatcher(common.universe, watcherId, claimTimeout, common.timingReport) {
+      override protected def getManifest(u: Universe[common.CT, common.CV] with
+                                         SecondaryManifestProvider with PlaybackToSecondaryProvider):
+        SecondaryManifest = testManifest
+    }
+
+
+    for { u <- common.universe } {
+      val job = SecondaryRecord(testStoreId, watcherId, new DatasetId(10),
+                                startingDataVersion = 2L, endingDataVersion = 2L,
+                                startingLifecycleStage = LS.Published,
+                                retryNum = 0, initialCookie = None)
+      (testManifest.claimDatasetNeedingReplication _).expects(testStoreId, watcherId, claimTimeout).
+                                                      returns(Some(job))
+
+      // Mock a secondary, set up expectations
+      val testSecondary = mock[Secondary[common.CT, common.CV]]
+      // NOTE: these expectations are not really needed, just examples
+      // (testSecondary.wantsWorkingCopies _).expects().returns(true)
+      // (testSecondary.version _).expects(*, *, *, *).returns(None)
+
+      (testManifest.markSecondaryDatasetBroken _).expects(job)
+
+      // Run the watcher run() method
+      w.run(u, new NamedSecondary(testStoreId, testSecondary))
+
+      // Check that dataset marked broken
+    }
+  }
+}

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150528-add-column-retry-num.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150528-add-column-retry-num.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="evan" id="20150528-add-column-retry-num">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="secondary_manifest" columnName="retry_num"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="secondary_manifest">
+            <column name="retry_num" type="BIGINT" defaultValueNumeric="0">
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150601-add-column-initially-claimed-at.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150601-add-column-initially-claimed-at.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="evan" id="20150601-add-column-next-retry">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="secondary_manifest" columnName="initially_claimed_at"/>
+            </not>
+        </preConditions>
+        <sql>
+            ALTER TABLE secondary_manifest ADD initially_claimed_at TIMESTAMP WITH TIME ZONE;
+        </sql>
+        <rollback>
+            <sql>
+                ALTER TABLE secondary_manifest DROP COLUMN initially_claimed_at;
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150601-add-column-next-retry.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150601-add-column-next-retry.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="evan" id="20150601-add-column-next-retry">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="secondary_manifest" columnName="next_retry"/>
+            </not>
+        </preConditions>
+        <sql>
+            ALTER TABLE secondary_manifest ADD next_retry TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+        </sql>
+        <rollback>
+            <sql>
+                ALTER TABLE secondary_manifest DROP COLUMN next_retry;
+            </sql>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150601-add-column-next-retry.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150601-add-column-next-retry.xml
@@ -10,14 +10,15 @@
             </not>
         </preConditions>
         <sql>
-            ALTER TABLE secondary_manifest ADD next_retry TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
-            DROP INDEX IF EXISTS secondary_manifest_next_retry;
-            CREATE INDEX secondary_manifest_next_retry ON secondary_manifest(next_retry);
+            ALTER TABLE secondary_manifest ADD next_retry TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT CURRENT_TIMESTAMP;
+            DROP INDEX IF EXISTS secondary_manifest_order;
+            CREATE INDEX secondary_manifest_order ON secondary_manifest (store_id, (broken_at IS NULL), next_retry, (latest_data_version > latest_secondary_data_version), went_out_of_sync_at);
         </sql>
         <rollback>
             <sql>
                 ALTER TABLE secondary_manifest DROP COLUMN next_retry;
-                DROP INDEX IF EXISTS secondary_manifest_next_retry;
+                DROP INDEX IF EXISTS secondary_manifest_order;
+                CREATE INDEX secondary_manifest_order ON secondary_manifest (store_id, (broken_at IS NULL), (latest_data_version > latest_secondary_data_version), went_out_of_sync_at);
             </sql>
         </rollback>
     </changeSet>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150601-add-column-next-retry.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20150601-add-column-next-retry.xml
@@ -11,10 +11,13 @@
         </preConditions>
         <sql>
             ALTER TABLE secondary_manifest ADD next_retry TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP;
+            DROP INDEX IF EXISTS secondary_manifest_next_retry;
+            CREATE INDEX secondary_manifest_next_retry ON secondary_manifest(next_retry);
         </sql>
         <rollback>
             <sql>
                 ALTER TABLE secondary_manifest DROP COLUMN next_retry;
+                DROP INDEX IF EXISTS secondary_manifest_next_retry;
             </sql>
         </rollback>
     </changeSet>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -13,6 +13,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20140627-create-postgis-extension.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20140629-create-rollup-map.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20150501-add-missing-timezone.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20150528-add-column-retry-num.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -15,6 +15,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20150501-add-missing-timezone.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20150528-add-column-retry-num.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20150601-add-column-next-retry.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20150601-add-column-initially-claimed-at.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -14,6 +14,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20140629-create-rollup-map.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20150501-add-missing-timezone.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20150528-add-column-retry-num.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20150601-add-column-next-retry.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
@@ -6,9 +6,19 @@ import com.socrata.datacoordinator.truth.metadata
 import scala.concurrent.duration.FiniteDuration
 import java.util.UUID
 
-case class SecondaryRecord(storeId: String, claimantId: UUID, datasetId: DatasetId, startingDataVersion: Long, startingLifecycleStage: metadata.LifecycleStage, endingDataVersion: Long, initialCookie: Option[String])
+case class SecondaryRecord(storeId: String,
+                           claimantId: UUID,
+                           datasetId: DatasetId,
+                           startingDataVersion: Long,
+                           startingLifecycleStage: metadata.LifecycleStage,
+                           endingDataVersion: Long,
+                           initialCookie: Option[String])
+
 class DatasetAlreadyInSecondary(val storeId: String, val DatasetId: DatasetId) extends Exception
 
+/**
+ * Manages the manifest of replications to secondaries, persisted in a database.
+ */
 trait SecondaryManifest {
   def readLastDatasetInfo(storeId: String, datasetId: DatasetId): Option[(Long, Option[String])]
   @throws(classOf[DatasetAlreadyInSecondary])
@@ -19,10 +29,17 @@ trait SecondaryManifest {
   def stores(datasetId: DatasetId): Map[String, Long]
 
   def cleanOrphanedClaimedDatasets(storeId: String, claimantId: UUID)
-  def claimDatasetNeedingReplication(storeId: String, claimantId: UUID, claimTimeout: FiniteDuration): Option[SecondaryRecord]
+  def claimDatasetNeedingReplication(storeId: String,
+                                     claimantId: UUID,
+                                     claimTimeout: FiniteDuration): Option[SecondaryRecord]
   def releaseClaimedDataset(job: SecondaryRecord)
   def markSecondaryDatasetBroken(job: SecondaryRecord)
-  def completedReplicationTo(storeId: String, claimantId: UUID, datasetId: DatasetId, dataVersion: Long, lifecycleStage: metadata.LifecycleStage, newCookie: Option[String])
+  def completedReplicationTo(storeId: String,
+                             claimantId: UUID,
+                             datasetId: DatasetId,
+                             dataVersion: Long,
+                             lifecycleStage: metadata.LifecycleStage,
+                             newCookie: Option[String])
 }
 
 case class NamedSecondary[CT, CV](storeId: String, store: Secondary[CT, CV])

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
@@ -41,7 +41,7 @@ trait SecondaryManifest {
                              dataVersion: Long,
                              lifecycleStage: metadata.LifecycleStage,
                              newCookie: Option[String])
-  def updateRetryNum(storeId: String, datasetId: DatasetId, retryNum: Int)
+  def updateRetryInfo(storeId: String, datasetId: DatasetId, retryNum: Int, nextRetryDelaySecs: Int)
 }
 
 case class NamedSecondary[CT, CV](storeId: String, store: Secondary[CT, CV])

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
@@ -12,6 +12,7 @@ case class SecondaryRecord(storeId: String,
                            startingDataVersion: Long,
                            startingLifecycleStage: metadata.LifecycleStage,
                            endingDataVersion: Long,
+                           retryNum: Int,
                            initialCookie: Option[String])
 
 class DatasetAlreadyInSecondary(val storeId: String, val DatasetId: DatasetId) extends Exception
@@ -40,6 +41,7 @@ trait SecondaryManifest {
                              dataVersion: Long,
                              lifecycleStage: metadata.LifecycleStage,
                              newCookie: Option[String])
+  def updateRetryNum(storeId: String, datasetId: DatasetId, retryNum: Int)
 }
 
 case class NamedSecondary[CT, CV](storeId: String, store: Secondary[CT, CV])

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
@@ -168,11 +168,12 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
   }
 
   def markDatasetClaimedForReplication(job: SecondaryRecord) {
+    val initClaimedAtSql = if (job.retryNum == 0) ",initially_claimed_at = CURRENT_TIMESTAMP" else ""
     using(conn.prepareStatement(
-      """UPDATE secondary_manifest
+      s"""UPDATE secondary_manifest
         |SET claimed_at = CURRENT_TIMESTAMP
         |  ,claimant_id = ?
-        |WHERE store_id = ?
+        |$initClaimedAtSql WHERE store_id = ?
         |  AND dataset_system_id = ?""".stripMargin)) { stmt =>
       stmt.setObject(1, job.claimantId)
       stmt.setString(2, job.storeId)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
@@ -167,13 +167,14 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
     }
   }
 
+  // NOTE: claimed_at is updated in SecondaryWatcherClaimManager.  initially_claimed_at is not.
   def markDatasetClaimedForReplication(job: SecondaryRecord) {
-    val initClaimedAtSql = if (job.retryNum == 0) ",initially_claimed_at = CURRENT_TIMESTAMP" else ""
     using(conn.prepareStatement(
-      s"""UPDATE secondary_manifest
+      """UPDATE secondary_manifest
         |SET claimed_at = CURRENT_TIMESTAMP
+        |  ,initially_claimed_at = CURRENT_TIMESTAMP
         |  ,claimant_id = ?
-        |$initClaimedAtSql WHERE store_id = ?
+        |WHERE store_id = ?
         |  AND dataset_system_id = ?""".stripMargin)) { stmt =>
       stmt.setObject(1, job.claimantId)
       stmt.setString(2, job.storeId)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
@@ -95,7 +95,8 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
     }
   }
 
-  def claimDatasetNeedingReplication(storeId: String, claimantId: UUID, claimTimeout: FiniteDuration):Option[SecondaryRecord] = {
+  def claimDatasetNeedingReplication(storeId: String, claimantId: UUID, claimTimeout: FiniteDuration):
+      Option[SecondaryRecord] = {
     val job = using(conn.prepareStatement(
       """SELECT dataset_system_id
         |  ,latest_secondary_data_version
@@ -203,7 +204,12 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
     }
   }
 
-  def completedReplicationTo(storeId: String, claimantId: UUID, datasetId: DatasetId, dataVersion: Long, lifecycleStage: metadata.LifecycleStage, cookie: Option[String]) {
+  def completedReplicationTo(storeId: String,
+                             claimantId: UUID,
+                             datasetId: DatasetId,
+                             dataVersion: Long,
+                             lifecycleStage: metadata.LifecycleStage,
+                             cookie: Option[String]) {
     using(conn.prepareStatement(
       """UPDATE secondary_manifest
         |SET latest_secondary_data_version = ?

--- a/coordinatorlib/src/test/scala/com/socrata/datacoordinator/truth/loader/sql/TestSqlLoader.scala
+++ b/coordinatorlib/src/test/scala/com/socrata/datacoordinator/truth/loader/sql/TestSqlLoader.scala
@@ -18,6 +18,9 @@ import com.socrata.datacoordinator.util.collection.{MutableColumnIdMap, ColumnId
 import com.rojoma.json.v3.ast.{JString, JNumber, JValue}
 
 class TestSqlLoader extends FunSuite with MustMatchers with PropertyChecks with BeforeAndAfterAll {
+
+  Class.forName("org.h2.Driver") // force driver to load
+
   val executor = java.util.concurrent.Executors.newCachedThreadPool()
 
   override def afterAll() {

--- a/coordinatorlib/src/test/scala/com/socrata/datacoordinator/truth/reader/sql/SqlReaderTest.scala
+++ b/coordinatorlib/src/test/scala/com/socrata/datacoordinator/truth/reader/sql/SqlReaderTest.scala
@@ -12,6 +12,9 @@ import com.socrata.datacoordinator.util.collection.{ColumnIdSet, MutableColumnId
 import com.socrata.datacoordinator.id.{RowId, ColumnId}
 
 class SqlReaderTest extends FunSuite with MustMatchers with BeforeAndAfterAll {
+
+  Class.forName("org.h2.Driver") // force driver to load
+
   def datasetContext(s: ColumnIdMap[SqlColumnReadRep[TestColumnType, TestColumnValue]]) = new ReadOnlyRepBasedSqlDatasetContext[TestColumnType, TestColumnValue] {
     val schema = s
     val typeContext = TestTypeContext

--- a/project/Coordinator.scala
+++ b/project/Coordinator.scala
@@ -30,7 +30,9 @@ object Coordinator {
         "net.sf.opencsv"  % "opencsv"       % "2.3",
         "org.clojure"     % "clojure"       % "1.5.1",
 
-        TestDeps.scalaCheck % "test"
+        TestDeps.scalaCheck % "test",
+        TestDeps.scalaMock  % "test",
+        TestDeps.h2         % "test"
       )
     },
     mainClass in assembly := Some("com.socrata.datacoordinator.Launch"),

--- a/project/CoordinatorLib.scala
+++ b/project/CoordinatorLib.scala
@@ -27,7 +27,7 @@ object CoordinatorLib {
       TestDeps.scalaCheck  % "test,it",
       TestDeps.scalaTest   % "it",
       TestDeps.slf4jSimple % "test,it",
-      "com.h2database"     % "h2" % "1.3.166" % "test,it"
+      TestDeps.h2          % "test,it"
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,12 +3,14 @@ import sbt._
 object Dependencies {
   object versions {
     val c3po            = "0.9.5-pre9"
+    val h2              = "1.3.166"
     val metricsScala    = "3.3.0"
     val jodaConvert     = "1.2"
     val jodaTime        = "2.1"
     val rojomaJson      = "3.2.2"
     val rojomaSimpleArm = "1.1.10"
     val scalaCheck      = "1.11.0"
+    val scalaMock       = "3.2"
     val scalaTest       = "2.2.1"
     val slf4j           = "1.7.5"
     val soqlReference   = "0.5.3"
@@ -37,7 +39,9 @@ object Dependencies {
   val typesafeConfig = "com.typesafe" % "config" % versions.typesafeConfig
 
   object TestDeps {
+    val h2          = "com.h2database"  % "h2"           % versions.h2
     val scalaCheck  = "org.scalacheck" %% "scalacheck"   % versions.scalaCheck
+    val scalaMock   = "org.scalamock"  %% "scalamock-scalatest-support" % versions.scalaMock
     val scalaTest   = "org.scalatest"  %% "scalatest"    % versions.scalaTest
     val slf4jSimple = "org.slf4j"       % "slf4j-simple" % versions.slf4j
   }


### PR DESCRIPTION
This PR adds functionality to automatically retry on failure, with exponential back off.  More precisely, on failure, the dataset is marked broken only if the # of retries has not been exceeded; otherwise the retry information is updated in the secondary_manifest table, and the watcher can pick up the job again.

The back off interval and max number of retries can be configured in the secondary watcher .conf file.

Also, a test for the secondary watcher has been added.