### PR TITLE
Syntax error in updateRetryInfo

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
@@ -243,7 +243,7 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
     using(conn.prepareStatement(
       """UPDATE secondary_manifest
         |SET retry_num = ?
-        |  ,next_retry = CURRENT_TIMESTAMP + INTERVAL ?
+        |  ,next_retry = CURRENT_TIMESTAMP + (? :: INTERVAL)
         |WHERE store_id = ?
         |  AND dataset_system_id = ?""".stripMargin)) { stmt =>
       stmt.setInt(1, retryNum)


### PR DESCRIPTION
"interval '10 seconds'" is a special syntactic form, not a function
application, so "interval ?" does not work.  Instead, cast a string
value to an interval.

I noticed errors about this in the secondary watcher logs.