### PR TITLE
EN-3487 - align soql reference version with soql-postgres-adapter

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     val scalaCheck      = "1.11.0"
     val scalaMock       = "3.2"
     val slf4j           = "1.7.5"
-    val soqlReference   = "1.0.7"
+    val soqlReference   = "2.0.0"
     val thirdPartyUtils = "4.0.1"
     val curatorUtils    = "1.0.3"
     val typesafeConfig  = "1.2.1"


### PR DESCRIPTION
2016-03-03 03:04:30,477 ERROR [Worker 3 for secondary pg1-rc] () [] SecondaryWatcher Uncaught exception in thread Worker 3 for secondary pg1-rc, exiting
java.lang.NoSuchMethodError: com.socrata.soql.types.SoQLType$.typePreferences()Lscala/collection/Seq;
	at com.socrata.soql.functions.SoQLTypeInfo$.<init>(SoQLTypeInfo.scala:14)
	at com.socrata.soql.functions.SoQLTypeInfo$.<clinit>(SoQLTypeInfo.scala)
	at com.socrata.pg.store.RollupManager$$anonfun$doUpdateRollup$1.apply$mcV$sp(RollupManager.scala:90)
	at com.socrata.pg.store.RollupManager$$anonfun$doUpdateRollup$1.apply(RollupManager.scala:85)
	at com.socrata.pg.store.RollupManager$$anonfun$doUpdateRollup$1.apply(RollupManager.scala:85)