### PR TITLE
EN-3886: Change /manifest/secondaries-of-dataset

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
@@ -52,7 +52,7 @@ class Main(common: SoQLCommon, serviceConfig: ServiceConfig) {
         throw new Exception(s"Can't find secondary group $secondaryGroupStr")
       )
 
-      val currentDatasetSecondaries = secondariesOfDataset(datasetId).keySet
+      val currentDatasetSecondaries = secondariesOfDataset(datasetId).map(_.secondaries.keySet).getOrElse(Set.empty)
 
       val newSecondaries = Main.secondariesToAdd(secondaryGroup,
         currentDatasetSecondaries,
@@ -77,10 +77,16 @@ class Main(common: SoQLCommon, serviceConfig: ServiceConfig) {
     }
   }
 
-  def secondariesOfDataset(datasetId: DatasetId): Map[String, Long] = {
+  def secondariesOfDataset(datasetId: DatasetId): Option[SecondariesOfDatasetResult] = {
     for (u <- common.universe) yield {
-      val secondaryManifest = u.secondaryManifest
-      secondaryManifest.stores(datasetId)
+      val datasetMapReader = u.datasetMapReader
+      datasetMapReader.datasetInfo(datasetId).map { datasetInfo =>
+        val secondaryManifest = u.secondaryManifest
+        val truthVersion = datasetMapReader.latest(datasetInfo).dataVersion
+        val secondaries = secondaryManifest.stores(datasetId)
+        val feedbackSecondaries = secondaryManifest.feedbackSecondaries(datasetId)
+        SecondariesOfDatasetResult(truthVersion, secondaries, feedbackSecondaries)
+      }
     }
   }
 

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
@@ -46,6 +46,7 @@ trait SecondaryManifest {
 
   def updateReplayInfo(storeId: String, datasetId: DatasetId, cookie: Secondary.Cookie, replayNum: Int, nextReplayDelaySecs: Int): Unit
 
+  def feedbackSecondaries(datasetId: DatasetId): Set[String] // store IDs
   def outOfDateFeedbackSecondaries(datasetId: DatasetId): Set[String] // store IDs
 }
 

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
@@ -281,6 +281,21 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
     }
   }
 
+  def feedbackSecondaries(datasetId: DatasetId): Set[String] = { // store IDs =
+    using(conn.prepareStatement(
+      """SELECT sm.store_id
+        |  FROM secondary_manifest sm JOIN secondary_stores_config ssc ON sm.store_id = ssc.store_id
+        |  WHERE sm.dataset_system_id = ?
+        |        AND ssc.is_feedback_secondary""".stripMargin)) { stmt =>
+      stmt.setDatasetId(1, datasetId)
+      using(stmt.executeQuery()) { rs =>
+        val result = Set.newBuilder[String]
+        while(rs.next()) result += rs.getString(1)
+        result.result()
+      }
+    }
+  }
+
   def outOfDateFeedbackSecondaries(datasetId: DatasetId): Set[String] = { // store IDs =
     using(conn.prepareStatement(
       """SELECT sm.store_id


### PR DESCRIPTION
Enpoint now includes:
 - version of dataset in truth
 - map from secondary store ids to version
 - feedback secondary stores