### PR TITLE
EN-4304: Reset isolation level of transactions

### DIFF
--- a/coordinator/src/main/resources/reference.conf
+++ b/coordinator/src/main/resources/reference.conf
@@ -17,6 +17,7 @@ com.socrata.coordinator.common {
       testConnectionOnCheckin = true
       preferredTestQuery = "SELECT 1"
       maxIdleTimeExcessConnections = 300
+      connectionCustomizerClassName = com.socrata.datacoordinator.common.ConnectionResetter
     }
   }
 


### PR DESCRIPTION
Actually reset the isolation level of transactions
on check-in to the pool.