### PR TITLE
EN-4323: Fix resync with respect to discarded copies

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
@@ -297,9 +297,7 @@ class PlaybackToSecondary[CT, CV](u: PlaybackToSecondary.SuperUniverse[CT, CV],
             case Some(datasetInfo) =>
               val allCopies = r.allCopies(datasetInfo) // guarantied to be ordered by copy number
               val latestLiving = r.latest(datasetInfo).copyNumber // this is the newest _living_ copy
-              var latest: Option[metadata.CopyInfo] = None
               for (copy <- allCopies) {
-                latest = Some(copy)
                 val secondaryDatasetInfo = makeSecondaryDatasetInfo(copy.datasetInfo)
                 timingReport("copy", "number" -> copy.copyNumber) {
                   // secondary.store.resync(.) will be called
@@ -315,6 +313,7 @@ class PlaybackToSecondary[CT, CV](u: PlaybackToSecondary.SuperUniverse[CT, CV],
               // end transaction to not provoke a serialization error from touching the secondary_manifest table
               u.commit()
               // transaction isolation level is now reset to READ COMMITTED
+              val latest = allCopies.lastOption
               if (!latest.isDefined) // should always be a Some(.)...
                 logger.error("Have dataset info for dataset {}, but it has no copies?", datasetInfo.toString)
               latest

--- a/dummy-secondary/src/main/scala/com/socrata/dummysecondary/DummySecondary.scala
+++ b/dummy-secondary/src/main/scala/com/socrata/dummysecondary/DummySecondary.scala
@@ -10,8 +10,6 @@ import com.socrata.datacoordinator.secondary.DatasetInfo
 class DummySecondary(config: Config) extends Secondary[Any, Any] {
   def shutdown(): Unit = {}
 
-  val wantsWorkingCopies: Boolean = config.getBoolean("wants-working-copies")
-
   /** The dataset has been deleted. */
   def dropDataset(datasetInternalName: String, cookie: Secondary.Cookie): Unit = {
     println("Deleted dataset " + datasetInternalName)
@@ -30,15 +28,6 @@ class DummySecondary(config: Config) extends Secondary[Any, Any] {
    */
   def currentCopyNumber(datasetInternalName: String, cookie: Secondary.Cookie): Long =
     readLine("What copy of " + datasetInternalName + "? (" + cookie + ") ").toLong
-
-  /**
-   * @return The `copyNumber`s of all snapshot copies in this secondary.
-   */
-  def snapshots(datasetInternalName: String, cookie: Secondary.Cookie): Set[Long] =
-    readLine("Copy numbers of all snapshot for " + datasetInternalName + "? (" + cookie + ") ")
-      .split(',')
-      .map(_.toLong)
-      .toSet
 
   /**
    * Order this secondary to drop a snapshot.  This should ignore the request

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondary.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondary.scala
@@ -83,8 +83,6 @@ abstract class FeedbackSecondary[CT,CV, RCI <: RowComputeInfo[CV]] extends Secon
     }
   }
 
-  override def wantsWorkingCopies: Boolean = true
-
   /** The dataset has been deleted. */
   override def dropDataset(datasetInternalName: String, cookie: Cookie): Unit = {} // nothing to do here
 
@@ -109,11 +107,6 @@ abstract class FeedbackSecondary[CT,CV, RCI <: RowComputeInfo[CV]] extends Secon
       case None => log.debug("No existing cookie for dataset {}", datasetInternalName); 0
     }
   }
-
-  /**
-   * @return The `copyNumber`s of all snapshot copies in this secondary.
-   */
-  override def snapshots(datasetInternalName: String, cookie: Cookie): Set[Long] = Set.empty // no need for snapshots
 
   /**
    * In order for this secondary to drop a snapshot.  This should ignore the request

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/Secondary.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/Secondary.scala
@@ -9,8 +9,6 @@ trait Secondary[CT, CV] {
 
   def shutdown(): Unit
 
-  def wantsWorkingCopies: Boolean
-
   /** The dataset has been deleted. */
   def dropDataset(datasetInternalName: String, cookie: Cookie)
 
@@ -27,11 +25,6 @@ trait Secondary[CT, CV] {
   def currentCopyNumber(datasetInternalName: String, cookie: Cookie): Long
 
   /**
-   * @return The `copyNumber`s of all snapshot copies in this secondary.
-   */
-  def snapshots(datasetInternalName: String, cookie: Cookie): Set[Long]
-
-  /**
    * Order this secondary to drop a snapshot.  This should ignore the request
    * if the snapshot is already gone (but it should signal an error if the
    * copyNumber does not name a snapshot).
@@ -45,7 +38,7 @@ trait Secondary[CT, CV] {
   def version(datasetInfo: DatasetInfo, dataVersion: Long, cookie: Cookie, events: Iterator[Event[CT, CV]]): Cookie
 
   def resync(datasetInfo: DatasetInfo, copyInfo: CopyInfo, schema: ColumnIdMap[ColumnInfo[CT]], cookie: Cookie,
-             rows: Managed[Iterator[ColumnIdMap[CV]]], rollups: Seq[RollupInfo], isLatestCopy: Boolean): Cookie
+             rows: Managed[Iterator[ColumnIdMap[CV]]], rollups: Seq[RollupInfo], isLatestLivingCopy: Boolean): Cookie
 
 }
 


### PR DESCRIPTION
Fix resync for datasets with their latest copy being
a discarded copy. That is, actually set the correct
version (the version in truth) in the secondary manifest.

Also removes dead code path for secondaries that
don't want working copies (we have none).

-- Requires: secondaries to handle these changes
   appropriately, in particular: pg-secondary. --