### PR TITLE
EN-5912: Use Java8 base image for dockerizing secondary-watcher

### DIFF
--- a/coordinator/docker-secondary-watcher/Dockerfile
+++ b/coordinator/docker-secondary-watcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM socrata/java
+FROM socrata/java8
 
 # EXPOSE
 ENV JMX_PORT 6299


### PR DESCRIPTION
Jenkins jobs are updated to build the code with Java 8. Build passed in Jenkins when I ran it on this branch.

This is part 1 of 2 of updating secondary watchers to run as Java8. Once this is merged, I'll cut a new release/docker image. The base image for PG and spandex secondary watchers can then be bumped to this new version. FYI: @sokrahta 