### PR TITLE
Acquiring locks timeouts in 30s for migration.

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/primary/SchemaMigrator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/primary/SchemaMigrator.scala
@@ -16,7 +16,9 @@ object SchemaMigrator {
     for {
       dataSourceInfo <- DataSourceFromConfig(new DataSourceConfig(config, databaseTree))
       conn <- managed(dataSourceInfo.dataSource.getConnection)
+      stmt <- managed(conn.createStatement())
     } {
+      stmt.execute("SET lock_timeout = '30s'")
       Migration.migrateDb(conn, operation, numChanges)
     }
   }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/migration/Migration.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/migration/Migration.scala
@@ -27,7 +27,8 @@ object Migration {
                 operation: MigrationOperation = MigrationOperation.Migrate,
                 numChanges: Int = 1,
                 changeLogPath: String = MigrationScriptPath) {
-    val liquibase = new Liquibase(changeLogPath, new ClassLoaderResourceAccessor, new JdbcConnection(conn))
+    val jdbc = new NonCommmittingJdbcConnenction(conn)
+    val liquibase = new Liquibase(changeLogPath, new ClassLoaderResourceAccessor, jdbc)
     val database = conn.getCatalog
 
     operation match {
@@ -35,6 +36,7 @@ object Migration {
       case Undo => liquibase.rollback(numChanges, database)
       case Redo => { liquibase.rollback(numChanges, database); liquibase.update(database) }
     }
+    jdbc.realCommit()
   }
 
   private val MigrationScriptPath = "com.socrata.datacoordinator.truth.schema/migrate.xml"

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/migration/NonCommittingJdbcConnection.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/migration/NonCommittingJdbcConnection.scala
@@ -1,0 +1,26 @@
+package com.socrata.datacoordinator.truth.migration
+
+import java.sql.Connection
+
+import liquibase.database.jvm.JdbcConnection
+
+/**
+  * liquibase always commits at the end of a changeSet.
+  * This class override commit and allows multi-changeSets migration to be commit or rollback
+  * as one transaction.
+  *
+  * liquibase always rollbacks after prerequisite check.  Therefore, rollback is also ignored.
+  *
+  * When this connection is used for liquibase migration, changeSet.runInTransaction must be true(which is the default).
+  * Because this connection is twisted, it should not be used for anything except liquibase migration.
+  */
+class NonCommmittingJdbcConnenction(conn: Connection) extends JdbcConnection(conn) {
+
+  conn.setAutoCommit(false)
+
+  override def commit(): Unit = { }
+
+  override def rollback(): Unit = { }
+
+  def realCommit(): Unit = conn.commit()
+}


### PR DESCRIPTION
Run migration in one transaction.