### PR TITLE
EN-6889: Stop resyncing on computed column creation

### DIFF
--- a/coordinator-external/src/main/scala/com/socrata/datacoordinator/external/DataCoordinatorError.scala
+++ b/coordinator-external/src/main/scala/com/socrata/datacoordinator/external/DataCoordinatorError.scala
@@ -30,6 +30,7 @@ object ContentTypeRequestError{
 object ExportRequestError{
   val MISMATCHED_SCHEMA = "req.export.mismatched-schema"
   val INVALID_ROW_ID = "req.export.invalid-row-id"
+  val UNKNOWN_COLUMNS = "req.export.unknown-columns"
 }
 
 object BodyRequestError{

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/DatasetResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/DatasetResource.scala
@@ -218,6 +218,8 @@ case class DatasetResource(datasetId: DatasetId,
             case Exporter.NotModified(etags) => notModified(etags.map(_.append(suffix)))(resp)
             case Exporter.PreconditionFailedBecauseNoMatch => preconditionFailed(resp)
             case Exporter.InvalidRowId => datasetBadRequest(ExportRequestError.INVALID_ROW_ID)(resp)
+            case Exporter.UnknownColumns(columns) =>
+              datasetBadRequest(ExportRequestError.UNKNOWN_COLUMNS, ("columns", JsonEncode.toJValue(columns)))(resp)
           }
         }
       case Left(Precondition.FailedBecauseNoMatch) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -36,6 +36,7 @@ object Dependencies {
 
   val soqlEnvironment = "com.socrata" %% "soql-environment" % versions.soqlReference
   val soqlTypes       = "com.socrata" %% "soql-types"       % versions.soqlReference
+  val soqlStdlib      = "com.socrata" %% "soql-stdlib"      % versions.soqlReference
 
   val typesafeConfig = "com.typesafe" % "config" % versions.typesafeConfig
 

--- a/project/SecondaryLibFeedback.scala
+++ b/project/SecondaryLibFeedback.scala
@@ -9,6 +9,7 @@ object SecondaryLibFeedback {
       rojomaJson,
       rojomaSimpleArm,
       soqlEnvironment,
+      soqlStdlib,
       socrataCuratorUtils,
       "org.apache.curator" % "curator-x-discovery" % "2.8.0",
       "com.socrata" %% "socrata-http-client" % "3.6.2",

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/DataCoordinatorClient.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/DataCoordinatorClient.scala
@@ -1,0 +1,289 @@
+package com.socrata.datacoordinator.secondary.feedback
+
+import java.io.IOException
+
+import com.rojoma.json.v3.ast.{JString, JObject, JValue, JArray}
+import com.rojoma.json.v3.codec.{DecodeError, JsonDecode}
+import com.rojoma.json.v3.io.{JValueEventIterator, JsonReaderException}
+import com.rojoma.json.v3.util.{JsonUtil, NoTag, SimpleHierarchyCodecBuilder, AutomaticJsonCodecBuilder}
+import com.socrata.datacoordinator.id.UserColumnId
+import com.socrata.datacoordinator.secondary
+import com.socrata.datacoordinator.util.collection.MutableColumnIdMap
+import com.socrata.http.client.{HttpClient, RequestBuilder, SimpleHttpRequest}
+import com.socrata.http.client.exceptions.{HttpClientException, ContentTypeException}
+
+case class FeedbackFailure(reason: String, cause: Throwable) extends Exception(reason, cause)
+
+object FeedbackFailure {
+
+  def apply(reason: String): FeedbackFailure = FeedbackFailure(reason, null)
+}
+
+case class RowData[CV](pk: UserColumnId, rows: Iterator[secondary.Row[CV]])
+
+object DataCoordinatorClient {
+  def apply[CT,CV](httpClient: HttpClient,
+                   hostAndPort: String => Option[(String, Int)],
+                   retries: Int,
+                   typeFromJValue: JValue => Option[CT]): (String, CT => JValue => Option[CV]) => DataCoordinatorClient[CT,CV] =
+      new DataCoordinatorClient[CT,CV](httpClient, hostAndPort, retries, typeFromJValue, _, _)
+}
+
+class DataCoordinatorClient[CT,CV](httpClient: HttpClient,
+                                   hostAndPort: String => Option[(String, Int)],
+                                   retries: Int,
+                                   typeFromJValue: JValue => Option[CT],
+                                   datasetInternalName: String,
+                                   fromJValueFunc: CT => JValue => Option[CV]) {
+
+  val log = org.slf4j.LoggerFactory.getLogger(classOf[DataCoordinatorClient[CT,CV]])
+
+  private def datasetEndpoint: Option[String] = {
+    datasetInternalName.lastIndexOf('.') match {
+      case -1 =>
+        log.error("Could not extract data-coordinator instance name from dataset: {}", datasetInternalName)
+        throw new Exception(s"Could not extract data-coordinator instance name from dataset: $datasetInternalName")
+      case n =>
+        hostAndPort(datasetInternalName.substring(0, n)) match {
+          case Some((host, port)) => Some(s"http://$host:$port/dataset/$datasetInternalName")
+          case None => None
+        }
+    }
+  }
+
+  private def fail(message: String): Nothing = {
+    log.error(message)
+    throw FeedbackFailure(message)
+  }
+
+  private def fail(message: String, cause: Throwable): Nothing = {
+    log.error(message)
+    throw FeedbackFailure(message, cause)
+  }
+
+  private def failForResponse(message: String, code: Int, info: Any) =
+    fail(s"$message from data-coordinator for status $code: $info")
+
+  private val unexpected = "Received an unexpected error"
+  private val uninterpretable = "Unable to interpret error response"
+
+  private def unexpectedResponse(code: Int, response: ErrorResponse) =
+    failForResponse(unexpected, code, response)
+
+  private def uninterpretableResponse(code: Int, response: ErrorResponse) =
+    failForResponse(uninterpretable, code, response)
+
+  private def uninterpretableResponse(code: Int, error: DecodeError) =
+    failForResponse(uninterpretable, code, error)
+
+  private def retrying[T](actions: => T, remainingAttempts: Int = retries): T = {
+    val failure = try {
+      return actions
+    } catch {
+      case e: IOException => e
+      case e: HttpClientException => e
+      case e: JsonReaderException => e
+    }
+
+    log.info("Failure occurred while posting mutation script: {}", failure.getMessage)
+    if (remainingAttempts > 0) retrying(actions, remainingAttempts - 1)
+    else fail(s"Ran out of retry attempts after failure: ${failure.getMessage}", failure)
+  }
+
+  val UpdateDatasetDoesNotExist = "update.dataset.does-not-exist"
+  val UpdateRowUnknownColumn = "update.row.unknown-column"
+  val UpdateRowPrimaryKeyNonexistentOrNull = "update.row.primary-key-nonexistent-or-null"
+  val ReqExportUnknownColumns = "req.export.unknown-columns"
+
+  case class ErrorResponse(errorCode: String, data: JObject)
+  implicit val erCodec = AutomaticJsonCodecBuilder[ErrorResponse]
+
+  private def doRequest[T](request: SimpleHttpRequest,
+                           message: String,
+                           successHandle: JArray => T,
+                           badRequestHandle: ErrorResponse => T,
+                           serverErrorMessageExtra: String): Either[RequestFailure, T] = {
+    retrying[Either[RequestFailure, T]] {
+      httpClient.execute(request).run { resp =>
+        val start = System.nanoTime()
+        def logContentTypeFailure(v: => JValue): JValue =
+          try {
+            v
+          } catch {
+            case e: ContentTypeException =>
+              log.warn("The response from data-coordinator was not a valid JSON content type! The request we sent was: {}", request.toString)
+              fail("Unable to understand data-coordinator's response", e) // no retry here
+          }
+
+        resp.resultCode match {
+          case 200 =>
+            // success! ... well maybe...
+            val end = System.nanoTime()
+            log.info("{} in {}ms", message, (end - start) / 1000000)
+            JsonDecode.fromJValue[JArray](logContentTypeFailure(resp.jValue())) match {
+              case Right(response) => Right(successHandle(response))
+              case Left(e) => fail(s"Response from data-coordinator was not an array: ${e.english}")
+            }
+          case 400 =>
+            JsonDecode.fromJValue[ErrorResponse](logContentTypeFailure(resp.jValue())) match {
+              case Right(response) => Right(badRequestHandle(response))
+              case Left(e) => uninterpretableResponse(400, e)
+            }
+          case 404 =>
+            // { "errorCode" : "update.dataset.does-not-exist"
+            // , "data" : { "dataset" : "XXX.XXX, "data" : { "commandIndex" : 0 }
+            // }
+            JsonDecode.fromJValue[ErrorResponse](logContentTypeFailure(resp.jValue())) match {
+              case Right(ErrorResponse(UpdateDatasetDoesNotExist, _)) => Left(DatasetDoesNotExist)
+              case Right(response) => unexpectedResponse(404, response)
+              case Left(e) => uninterpretableResponse(404, e)
+            }
+          case 409 =>
+            // come back later!
+            Left(DataCoordinatorBusy) // no retry
+          case other =>
+            if (other == 500) {
+              log.warn("Scream! 500 from data-coordinator! Going to retry; {}", serverErrorMessageExtra)
+            }
+            // force a retry
+            throw new IOException(s"Unexpected result code $other from data-coordinator")
+        }
+      }
+    }
+  }
+
+  case class Column(c: UserColumnId, t: JValue)
+  case class Schema(pk: UserColumnId, schema: Seq[Column])
+
+  implicit val coCodec = AutomaticJsonCodecBuilder[Column]
+  implicit val scCodec = AutomaticJsonCodecBuilder[Schema]
+
+  /**
+   * Export the rows of a dataset for the given columns
+   * @param columnSet must contain at least on column
+   */
+  def exportRows(columnSet: Seq[UserColumnId], cookie: CookieSchema): Either[RequestFailure, Either[ColumnsDoNotExist, RowData[CV]]] = {
+    require(columnSet.nonEmpty, "`columnSet` must be non-empty")
+    log.info("Exporting rows for columns: {}", columnSet)
+    val endpoint = datasetEndpoint.getOrElse(return Left(FailedToDiscoverDataCoordinator))
+    val columns = columnSet.tail.foldLeft(columnSet.head.underlying) { (str, id) => str + "," + id.underlying }
+    val builder = RequestBuilder(new java.net.URI(endpoint)).addParameter(("c", columns))
+
+    def successHandle(response: JArray): Either[ColumnsDoNotExist, RowData[CV]] = {
+      if (response.isEmpty) fail("Response from data-coordinator was an empty array.")
+
+      JsonDecode.fromJValue[Schema](response.head) match {
+        case Right(Schema(pk, schema)) =>
+          val columns = schema.map { col =>
+            (cookie.columnIdMap(col.c), typeFromJValue(col.t).getOrElse {
+              fail(s"Could not derive column type for column ${col.c} from value: ${col.t}")
+            })
+          }.toArray
+          val rows = response.tail.iterator.map {
+            JsonDecode.fromJValue[JArray](_) match {
+              case Right(row) =>
+                assert(row.size == columns.size)
+                val colIdMap = new MutableColumnIdMap[CV]
+                row.iterator.zipWithIndex.foreach { case (jVal, index) =>
+                  val (colId, typ) = columns(index)
+                  colIdMap += ((colId, fromJValueFunc(typ)(jVal).getOrElse {
+                    fail(s"Could not interpret column value of type $typ from value: $jVal")
+                  }))
+                }
+                colIdMap.freeze()
+              case Left(e) => failForResponse("Row data was not an array", 200, e.english)
+            }
+          }
+          Right(RowData(pk, rows))
+        case Left(e) => failForResponse("Response did not start with expected column schema", 200, e.english)
+      }
+    }
+
+    def badRequestHandle(response: ErrorResponse): Either[ColumnsDoNotExist, RowData[CV]] = response match {
+      case ErrorResponse(ReqExportUnknownColumns, data) =>
+        JsonDecode.fromJValue[Set[UserColumnId]](data.getOrElse("columns", uninterpretableResponse(400, response))) match {
+        case Right(unknown) if unknown.nonEmpty => Left(ColumnsDoNotExist(unknown))
+        case _ => uninterpretableResponse(400, response)
+      }
+      case _ => unexpectedResponse(400, response)
+    }
+
+    doRequest(
+      request = builder.get,
+      message = s"Got row data for columns $columns",
+      successHandle,
+      badRequestHandle,
+      serverErrorMessageExtra = s"my parameters where: c=$columns"
+    )
+  }
+
+  sealed abstract class Response
+  case class Upsert(typ: String, id: String, ver: String) extends Response
+  case class NonfatalError(typ: String, err: String, id: Option[String]) extends Response
+
+  implicit val upCodec = AutomaticJsonCodecBuilder[Upsert]
+  implicit val neCodec = AutomaticJsonCodecBuilder[NonfatalError]
+  implicit val reCodec = SimpleHierarchyCodecBuilder[Response](NoTag).branch[Upsert].branch[NonfatalError].build
+
+  // this may throw a FeedbackFailure exception
+  def postMutationScript(script: JArray, cookie: CookieSchema): Option[Either[RequestFailure, UpdateSchemaFailure]] = {
+    val endpoint = datasetEndpoint.getOrElse(return Some(Left(FailedToDiscoverDataCoordinator)))
+    val builder = RequestBuilder(new java.net.URI(endpoint))
+
+    def body = JValueEventIterator(script)
+
+    def successHandle(response: JArray): Option[UpdateSchemaFailure] = {
+      assert(response.elems.length == 1, "Response contains more than one element")
+      JsonDecode.fromJValue[JArray](response.elems.head) match {
+        case Right(results) =>
+          assert(results.elems.length == script.elems.length - 2, "Did not get one result for each upsert command that was sent")
+          val rows = script.elems.slice(2, script.elems.length)
+          results.elems.zip(rows).foreach { case (result, row) =>
+            JsonDecode.fromJValue[Response](result) match {
+              case Right(Upsert("update", _, _)) => // yay!
+              case Right(NonfatalError("error", "insert_in_update_only", Some(id))) =>
+                val JObject(fields) = JsonDecode.fromJValue[JObject](row).right.get // I just encoded this from a JObject
+                val rowId = JsonDecode.fromJValue[JString](fields(cookie.primaryKey.underlying)).right.get.string
+                if (rowId != id) return Some(PrimaryKeyColumnHasChanged) // else the row has been deleted
+              case Right(other) => failForResponse("Unexpected response in array", 200, other)
+              case Left(e) => failForResponse("Unable to interpret result in array", 200, e.english)
+            }
+          }
+          None
+        case Left(e) => failForResponse("Row data was not an array", 200, e.english)
+      }
+    }
+
+    def badRequestHandle(response: ErrorResponse): Option[UpdateSchemaFailure] = {
+      response.errorCode match {
+        // { "errorCode" : "update.row.unknown-column"
+        // , "data" : { "commandIndex" : 1, "commandSubIndex" : XXX, "dataset" : "XXX.XXX", "column" : "XXXX-XXXX"
+        // }
+        case UpdateRowUnknownColumn => response.data.get("column") match {
+          case Some(JString(id)) =>
+            val userId = new UserColumnId(id)
+            if (id == cookie.primaryKey.underlying) Some(PrimaryKeyColumnDoesNotExist(userId))
+            else Some(TargetColumnDoesNotExist(userId))
+          case _ => uninterpretableResponse(400, response)
+        }
+        // { "errorCode" : "update.row.primary-key-nonexistent-or-null"
+        // , "data" : { "commandIndex" : 1, "dataset" : "XXX.XXX"
+        // }
+        case UpdateRowPrimaryKeyNonexistentOrNull => Some(PrimaryKeyColumnHasChanged)
+        case _ => unexpectedResponse(400, response)
+      }
+    }
+
+    doRequest(
+      request = builder.json(body),
+      message = s"Posted mutation script with ${script.length - 2} row updates",
+      successHandle,
+      badRequestHandle,
+      serverErrorMessageExtra = s"my mutation script was: ${JsonUtil.renderJson(script, pretty = false)}"
+    ) match {
+      case Left(failure) => Some(Left(failure))
+      case Right(Some(failure)) => Some(Right(failure))
+      case Right(None) => None
+    }
+  }
+}

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
@@ -1,0 +1,345 @@
+package com.socrata.datacoordinator.secondary.feedback
+
+import com.rojoma.json.v3.ast._
+import com.rojoma.json.v3.codec.JsonEncode
+import com.rojoma.json.v3.interpolation._
+import com.socrata.datacoordinator.id.UserColumnId
+import com.socrata.datacoordinator.secondary
+import com.socrata.datacoordinator.secondary.feedback.monitor.StatusMonitor
+import com.socrata.datacoordinator.secondary.{BrokenDatasetSecondaryException, ReplayLaterSecondaryException}
+import com.socrata.datacoordinator.util.collection.MutableColumnIdMap
+
+case class Row[CV](data: secondary.Row[CV], oldData: Option[secondary.Row[CV]])
+
+object FeedbackContext {
+  def apply[CT,CV](user: String,
+                   batchSize: Int => Int,
+                   statusMonitor: StatusMonitor,
+                   computationHandlers:  Seq[ComputationHandler[CT,CV]],
+                   computationRetryLimit: Int,
+                   dataCoordinator: (String, CT => JValue => Option[CV]) => DataCoordinatorClient[CT,CV],
+                   dataCoordinatorRetryLimit: Int,
+                   datasetContext: (String, CV => JValue, CT => JValue => Option[CV])): FeedbackCookie => FeedbackContext[CT,CV] = {
+    val (datasetInternalName, toJValueFunc, fromJValueFunc) = datasetContext
+    new FeedbackContext(
+      user,
+      batchSize,
+      statusMonitor,
+      computationHandlers,
+      computationRetryLimit,
+      dataCoordinator,
+      dataCoordinatorRetryLimit,
+      datasetInternalName,
+      toJValueFunc,
+      fromJValueFunc,
+      _
+    )
+  }
+}
+
+class FeedbackContext[CT,CV](user: String,
+                             batchSize: Int => Int,
+                             statusMonitor: StatusMonitor,
+                             computationHandlers: Seq[ComputationHandler[CT,CV]],
+                             computationRetryLimit: Int,
+                             dataCoordinator: (String, CT => JValue => Option[CV]) => DataCoordinatorClient[CT,CV],
+                             dataCoordinatorRetryLimit: Int,
+                             datasetInternalName: String,
+                             toJValueFunc: CV => JValue,
+                             fromJValueFunc: CT => JValue => Option[CV],
+                             feedbackCookie: FeedbackCookie) {
+
+  val log = org.slf4j.LoggerFactory.getLogger(classOf[FeedbackContext[CT,CV]])
+  private var cookie = feedbackCookie.current
+
+  val dataCoordinatorClient = dataCoordinator(datasetInternalName, fromJValueFunc)
+
+  def mergeWith[A, B](xs: Map[A, B], ys: Map[A, B])(f: (B, B) => B): Map[A, B] = {
+    ys.foldLeft(xs) { (combined, yab) =>
+      val (a, yb) = yab
+      val newB = combined.get(a) match {
+        case None => yb
+        case Some(xb) => f(xb, yb)
+      }
+      combined.updated(a, newB)
+    }
+  }
+
+  // this may throw a ComputationFailure exception
+  private def computeUpdates(computationHandler: ComputationHandler[CT,CV],
+                             rows: IndexedSeq[Row[CV]],
+                             targetColumns: Set[UserColumnId]): Map[Int, Map[UserColumnId, CV]] = {
+    val perDatasetData = computationHandler.setupDataset(cookie)
+    val perColumnData = cookie.strategyMap.toSeq.collect {
+      case (targetCol, strat) if targetColumns.contains(targetCol) & computationHandler.matchesStrategyType(strat.strategyType) =>
+        computationHandler.setupColumn(perDatasetData, strat, targetCol)
+    }
+    val toCompute = rows.iterator.zipWithIndex.flatMap { case (row, index) =>
+      val rcis =
+        perColumnData.flatMap { columnData =>
+          // don't compute if there has been to change to the source columns
+          if (noChange(row, columnData.strategy.sourceColumnIds))
+            None
+          else
+            Some(computationHandler.setupCell(columnData, row.data))
+        }
+      if (rcis.isEmpty) Iterator.empty
+      else Iterator.single(index -> rcis)
+    }.toMap
+
+    val results = computationHandler.compute(toCompute)
+
+    results.flatMap { case (rowIdx, updates) =>
+      val row = rows(rowIdx)
+      val filtered = updates.filter { case (colId: UserColumnId, value) =>
+        extractCV(row.data, colId) != Some(value) // don't update to current value
+      }
+      val rowId = extractCV(row.data, cookie.primaryKey) match {
+        case None => throw new Exception(s"Cannot find value for primary key ${cookie.primaryKey} in row: $row!")
+        case Some(other) => other
+      }
+      if (filtered.nonEmpty) {
+        val newRow = Map(
+          cookie.primaryKey -> rowId
+        ) ++ filtered.map { case (id, value) => (id, value)}.toMap
+        Some(rowIdx -> newRow)
+      } else {
+        None
+      }
+    }
+  }
+
+  private def noChange(row: Row[CV], columns: Seq[UserColumnId]): Boolean = row.oldData match {
+    case Some(old) =>
+      columns.forall { id =>
+        val internal = cookie.columnIdMap(id)
+        row.data(internal) == old(internal) // safe because updates contain _all_ row values (and this must be one)
+      }
+    case None => false
+  }
+
+  private def extractCV(row: secondary.Row[CV], userId: UserColumnId): Option[CV] = {
+    val internal = cookie.columnIdMap(userId)
+    row.get(internal)
+  }
+
+  // commands for mutation scripts
+  private val commands: Seq[JValue] =
+    j"""[ { "c" : "normal", "user" : $user }
+        , { "c" : "row data", "update_only" : true, "nonfatal_row_errors" : [ "insert_in_update_only" ] }
+        ]""".toSeq
+
+  private def writeMutationScript(rowUpdates: Iterator[JValue]): Option[JArray] = {
+    if (!rowUpdates.hasNext) None
+    else Some(JArray(commands ++ rowUpdates))
+  }
+
+  // this may throw a ReplayLaterSecondaryException or a BrokenDatasetSecondaryException
+  def feedback(rows: Iterator[Row[CV]],
+               targetColumns: Set[UserColumnId] = cookie.strategyMap.keySet,
+               resync: Boolean = false): FeedbackCookie = {
+    val width = cookie.columnIdMap.size
+    val size = batchSize(width)
+
+    log.info("Feeding back rows with batch_size = {} for target computed columns: {}", size, targetColumns)
+
+    def maybeThrowBroken(retriesLeft: Int, cause: String): Int = {
+      val gaveUp = s"Gave up replaying updates after too many failed $cause attempts"
+      if (retriesLeft == 0) throw new BrokenDatasetSecondaryException(gaveUp)
+      retriesLeft
+    }
+
+    var count = 0
+    try {
+      rows.grouped(size).foreach { batchSeq =>
+        val batch: Seq[Row[CV]] = batchSeq.toIndexedSeq
+        count += 1
+        val updates = computationHandlers.foldLeft(Map.empty[Int, Map[UserColumnId, CV]]) { (currentUpdates, computationHandler) =>
+          val currentRows = batch.toArray
+          for ((idx, upds) <- currentUpdates) {
+            val currentRow = MutableColumnIdMap(currentRows(idx).data)
+            for ((cid, cv) <- upds) {
+              currentRow(cookie.columnIdMap(cid)) = cv
+            }
+            currentRows(idx) = currentRows(idx).copy(data = currentRow.freeze())
+          }
+          val newUpdates = computeUpdates(computationHandler, currentRows, targetColumns)
+          mergeWith(currentUpdates, newUpdates)(_ ++ _)
+        }
+        val jsonUpdates = updates.valuesIterator.map { updates =>
+          JsonEncode.toJValue(updates.mapValues(toJValueFunc))
+        }
+        writeMutationScript(jsonUpdates) match {
+          case Some(script) =>
+            dataCoordinatorClient.postMutationScript(script, cookie) match {
+              case None =>
+                log.info("Finished batch {} of approx. {} rows", count, size)
+                statusMonitor.update(datasetInternalName, cookie.dataVersion, size, count)
+              case Some(Right(TargetColumnDoesNotExist(column))) =>
+                // this is pretty lame; but better than doing a full resync
+                val deleted = deleteColumns(Set(column))
+                computeColumns(targetColumns -- deleted)
+              case Some(Right(PrimaryKeyColumnHasChanged)) =>
+                // the primary key column has changed; try again
+                // computeColumns(.) will discover the new primary key
+                computeColumns(targetColumns)
+              case Some(Right(PrimaryKeyColumnDoesNotExist(column))) =>
+                // that's okay, we can try again
+                val deleted = deleteColumns(Set(column))
+                computeColumns(targetColumns -- deleted)
+              case Some(Left(ftddc@FailedToDiscoverDataCoordinator)) =>
+                log.warn("Failed to discover data-coordinator; going to request to have this dataset replayed later")
+                // we will retry this "indefinitely"; do not decrement retries left
+                throw ReplayLaterSecondaryException(ftddc.english, FeedbackCookie.encode(feedbackCookie.copy(current = cookie.copy(resync = resync))))
+              case Some(Left(ddb@DataCoordinatorBusy)) =>
+                log.info("Received a 409 from data-coordinator; going to request to have this dataset replayed later")
+                // we will retry this "indefinitely"; do not decrement retries left
+                throw ReplayLaterSecondaryException(ddb.english, FeedbackCookie.encode(feedbackCookie.copy(current = cookie.copy(resync = resync))))
+              case Some(Left(ddne@DatasetDoesNotExist)) =>
+                log.info("Completed updating dataset {} to version {} early: {}", datasetInternalName, cookie.dataVersion.underlying.toString, ddne.english)
+                statusMonitor.remove(datasetInternalName, cookie.dataVersion, count)
+
+                // nothing more to do here
+                return feedbackCookie.copy(
+                  current = cookie.copy(
+                    computationRetriesLeft = 0,
+                    dataCoordinatorRetriesLeft = 0,
+                    resync = false
+                  )
+                )
+            }
+          case None =>
+            log.info("Batch {} had no rows to update of approx. {} rows; no script posted.", count, size)
+            statusMonitor.update(datasetInternalName, cookie.dataVersion, size, count)
+        }
+      }
+    } catch {
+      case ComputationFailure(reason, cause) =>
+        // Some failure has occurred in computation; we will only retry these exceptions so many times
+        val newCookie = feedbackCookie.copy(
+          current = cookie.copy(
+            computationRetriesLeft = maybeThrowBroken(cookie.computationRetriesLeft - 1, "computation"), // decrement retries
+            dataCoordinatorRetriesLeft = dataCoordinatorRetryLimit, // reset mutation script retries
+            resync = resync
+          )
+        )
+        throw ReplayLaterSecondaryException(reason, FeedbackCookie.encode(newCookie))
+      case FeedbackFailure(reason, cause) =>
+        // We failed to post our mutation script to data-coordinator for some reason
+        val newCookie = feedbackCookie.copy(
+          current = cookie.copy(
+            computationRetriesLeft = computationRetryLimit, // reset computation retries
+            dataCoordinatorRetriesLeft = maybeThrowBroken(cookie.dataCoordinatorRetriesLeft - 1, "mutation script"), // decrement retries
+            resync = resync
+          )
+        )
+        throw ReplayLaterSecondaryException(reason, FeedbackCookie.encode(newCookie))
+    }
+    log.info("Completed row update of dataset {} in version {} after batch: {}",
+      datasetInternalName, cookie.dataVersion.underlying.toString, count.toString)
+    statusMonitor.remove(datasetInternalName, cookie.dataVersion, count)
+
+    // success!
+    feedbackCookie.copy(
+      current = cookie.copy(
+        computationRetriesLeft = 0,
+        dataCoordinatorRetriesLeft = 0,
+        resync = false
+      )
+    )
+  }
+
+  def flushColumnCreations(newColumns: Set[UserColumnId]): FeedbackCookie = {
+    if (newColumns.nonEmpty) {
+      log.info("Flushing newly created columns...")
+      val updatedCookie = computeColumns(newColumns)
+      log.info("Done flushing columns")
+      updatedCookie
+    } else {
+      feedbackCookie
+    }
+  }
+
+  // this is "safe" because we must be caught up before a publication stage change can be made
+  private def deleteColumns(columns: Set[UserColumnId]): Set[UserColumnId] = {
+    log.info("Columns have been deleted in truth: {}; updating the cookie.", columns)
+
+    val reverseStrategyMap = scala.collection.mutable.Map[UserColumnId, Set[UserColumnId]]()
+    cookie.strategyMap.foreach { case (target, strategy) =>
+      strategy.sourceColumnIds.foreach { source =>
+        reverseStrategyMap.put(source, reverseStrategyMap.getOrElse(source, Set.empty) + target)
+      }
+    }
+
+    def findReliantColumns(column: UserColumnId): Set[UserColumnId] = {
+      val reliant = scala.collection.mutable.Set[UserColumnId]()
+
+      val queue = scala.collection.mutable.Queue[UserColumnId](column)
+      while (queue.nonEmpty) {
+        reverseStrategyMap.getOrElse(queue.dequeue(), Set.empty).foreach { parent =>
+          if (reliant.add(parent)) queue.enqueue(parent)
+        }
+      }
+
+      reliant.toSet
+    }
+
+    val deleted = columns.flatMap(findReliantColumns) // includes starting columns
+    val reliant = deleted.filter(cookie.strategyMap.contains)
+
+    if (reliant.nonEmpty) log.info("Reliant computed columns have also been deleted: {}; updating the cookie.", reliant)
+
+    cookie = cookie.copy(
+      columnIdMap = cookie.columnIdMap -- deleted,
+      strategyMap = cookie.strategyMap -- reliant
+    )
+
+    deleted // all deleted columns and reliant computed columns that must also be deleted
+  }
+
+  private def computeColumns(targetColumns: Set[UserColumnId]): FeedbackCookie = {
+    if (targetColumns.nonEmpty) {
+      log.info("Computing columns: {}", targetColumns)
+      val columns = targetColumns.map(cookie.strategyMap(_)).flatMap(_.sourceColumnIds).toSet.toSeq
+
+      dataCoordinatorClient.exportRows(columns, cookie) match {
+        case Right(Right(RowData(pk, rows))) =>
+          if (pk != cookie.primaryKey) {
+            log.info(s"The primary key column has changed from ${cookie.primaryKey} to $pk; updating the cookie.")
+            // this is safe because I must be caught up before a publication stage change can be made
+            cookie = cookie.copy(primaryKey = pk)
+          }
+          val resultCookie = feedback(rows.map { row => Row(row, None) }, targetColumns)
+          log.info("Done computing columns")
+          resultCookie
+        case Right(Left(ColumnsDoNotExist(unknown))) =>
+          // since source columns must be deleted after computed columns
+          // just delete those unknown columns and associated compute columns from our cookie
+          // we'll get the event replayed to us later
+          val deleted = deleteColumns(unknown)
+          computeColumns(targetColumns -- deleted) // try to compute the un-deleted columns again
+        case Left(ftddc@FailedToDiscoverDataCoordinator) =>
+          log.warn("Failed to discover data-coordinator; going to request to have this dataset replayed later")
+          // we will retry this "indefinitely"; do not decrement retries left
+          throw ReplayLaterSecondaryException(ftddc.english, FeedbackCookie.encode(feedbackCookie))
+        case Left(ddb@DataCoordinatorBusy) =>
+          log.info("Received a 409 from data-coordinator; going to request to have this dataset replayed later")
+          // we will retry this "indefinitely"; do not decrement retries left
+          throw ReplayLaterSecondaryException(ddb.english, FeedbackCookie.encode(feedbackCookie))
+        case Left(ddne@DatasetDoesNotExist) =>
+          log.info("Completed updating dataset {} to version {} early: {}", datasetInternalName, cookie.dataVersion.underlying.toString, ddne.english)
+
+          // nothing more to do here
+          feedbackCookie.copy(
+            current = cookie.copy(
+              computationRetriesLeft = 0,
+              dataCoordinatorRetriesLeft = 0,
+              resync = false
+            )
+          )
+      }
+    } else {
+      feedbackCookie
+    }
+  }
+}

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackCookie.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackCookie.scala
@@ -41,7 +41,7 @@ case class CookieSchema(dataVersion: DataVersion,
                         strategyMap: Map[UserColumnId, ComputationStrategyInfo],
                         obfuscationKey: Array[Byte],
                         computationRetriesLeft: Int,
-                        mutationScriptRetriesLeft: Int,
+                        dataCoordinatorRetriesLeft: Int,
                         resync: Boolean) {
 
   override def equals(any: Any): Boolean = {
@@ -54,7 +54,7 @@ case class CookieSchema(dataVersion: DataVersion,
           this.strategyMap == other.strategyMap &&
           java.util.Arrays.equals(this.obfuscationKey, other.obfuscationKey) && // stupid arrays
           this.computationRetriesLeft == other.computationRetriesLeft &&
-          this.mutationScriptRetriesLeft == other.mutationScriptRetriesLeft &&
+          this.dataCoordinatorRetriesLeft == other.dataCoordinatorRetriesLeft &&
           this.resync == other.resync
       case _ => false
     }
@@ -69,7 +69,7 @@ case class CookieSchema(dataVersion: DataVersion,
     code = code * 41 + (if (strategyMap == null) 0 else strategyMap.hashCode)
     code = code * 41 + java.util.Arrays.hashCode(obfuscationKey)
     code = code * 41 + computationRetriesLeft.hashCode
-    code = code * 41 + mutationScriptRetriesLeft.hashCode
+    code = code * 41 + dataCoordinatorRetriesLeft.hashCode
     code = code * 41 + resync.hashCode
     code
   }

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondary.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondary.scala
@@ -3,20 +3,14 @@ package com.socrata.datacoordinator.secondary.feedback
 import java.io.IOException
 
 import com.rojoma.json.v3.ast._
-import com.rojoma.json.v3.codec.{JsonEncode, JsonDecode}
-import com.rojoma.json.v3.io.{JValueEventIterator, JsonReaderException}
-import com.rojoma.json.v3.util.{NoTag, SimpleHierarchyCodecBuilder, JsonUtil, AutomaticJsonCodecBuilder}
 import com.rojoma.simplearm.Managed
-import com.socrata.datacoordinator.id.{ColumnId, UserColumnId, StrategyType}
+import com.socrata.datacoordinator.id.{UserColumnId, StrategyType}
 import com.socrata.datacoordinator.secondary
 import com.socrata.datacoordinator.secondary._
 import com.socrata.datacoordinator.secondary.Secondary.Cookie
 import com.socrata.datacoordinator.secondary.feedback.monitor.StatusMonitor
-import com.socrata.datacoordinator.util.collection.{MutableColumnIdMap, ColumnIdMap}
-import com.socrata.http.client.{RequestBuilder, HttpClient}
-import com.socrata.http.client.exceptions.{ContentTypeException, HttpClientException}
-
-import scala.collection.SortedSet
+import com.socrata.datacoordinator.util.collection.ColumnIdMap
+import com.socrata.http.client.HttpClient
 
 trait HasStrategy {
   def strategy: ComputationStrategyInfo
@@ -62,41 +56,83 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
 
   val log = org.slf4j.LoggerFactory.getLogger(classOf[FeedbackSecondary[CT,CV]])
 
-  val httpClient: HttpClient
-  def hostAndPort(instanceName: String): Option[(String, Int)]
-  val baseBatchSize: Int
-  val internalMutationScriptRetries: Int
-  val mutationScriptRetries: Int
-  val computationHandlers: Seq[ComputationHandler[CT, CV]]
   /**
-   * @return The `user` to specify in mutation scripts
+   * The `user` to specify in mutation scripts
    */
   val user: String
 
   /**
-   * @return The number of times to retry the computation step via replaying later.
+   * The batch size of mutation scripts and general processing; should be a function of `width` of dataset.
    */
-  val retryLimit: Int
-  val repFor: Array[Byte] => CT => CV => JValue
-  val typeFor : CV => Option[CT]
-  val statusMonitor: StatusMonitor
+  val baseBatchSize: Int
 
-  private val systemId = new UserColumnId(":id")
+  def batchSize(width: Int): Int = baseBatchSize // TODO: figure out what this should be
 
   /**
-   * @return The batch size of mutation scripts and general processing; should be a function of `width` of dataset.
+   * The status monitor to report upon completion of batches for datasets
    */
-  def batchSize(width: Int): Int = 10000 // TODO: figure out what this should be
+  val statusMonitor: StatusMonitor
 
-  def toJValue(obfuscationKey: Array[Byte]): CV => JValue = {
+  /**
+   * HTTP connection to data-coordinator and corresponding retry limits
+   */
+  val httpClient: HttpClient
+
+  def hostAndPort(instanceName: String): Option[(String, Int)]
+
+  val dataCoordinatorRetryLimit: Int
+  val internalDataCoordinatorRetryLimit: Int
+
+  /**
+   * Computation handlers and corresponding retry limit
+   */
+  val computationHandlers: Seq[ComputationHandler[CT,CV]]
+  val computationRetryLimit: Int
+
+  /**
+   * Functions for converting between json and column types and values
+   */
+  val repFor: Array[Byte] => CT => CV => JValue
+  val repFrom: Array[Byte] => CT => JValue => Option[CV]
+  val typeFor: CV => Option[CT]
+  val typeFromJValue: JValue => Option[CT]
+
+  private def toJValue(obfuscationKey: Array[Byte]): CV => JValue = {
     val reps = repFor(obfuscationKey);
     { value: CV =>
-     typeFor(value) match {
-       case Some(typ) => reps(typ)(value)
-       case None => JNull
-     }
+      typeFor(value) match {
+        case Some(typ) => reps(typ)(value)
+        case None => JNull
+      }
     }
   }
+
+  private def fromJValue(obfuscationKey: Array[Byte]): CT => JValue => Option[CV] = {
+    val reps = repFrom(obfuscationKey);
+    reps
+  }
+
+  // this is a lazy val because we want abstract `httpClient` to be initialized first
+  private lazy val dataCoordinator = {
+    assert(httpClient != null)
+    DataCoordinatorClient[CT,CV](httpClient, hostAndPort, internalDataCoordinatorRetryLimit, typeFromJValue)
+  }
+
+  private def datasetContext(datasetInternalName: String,
+                             toJValueFunc: CV => JValue,
+                             fromJValueFunc: CT => JValue => Option[CV]): FeedbackCookie => FeedbackContext[CT,CV] =
+    FeedbackContext(
+      user,
+      batchSize,
+      statusMonitor,
+      computationHandlers,
+      computationRetryLimit,
+      dataCoordinator,
+      dataCoordinatorRetryLimit,
+      datasetContext = (datasetInternalName, toJValueFunc, fromJValueFunc)
+    )
+
+  private val systemId = new UserColumnId(":id")
 
   /** The dataset has been deleted. */
   override def dropDataset(datasetInternalName: String, cookie: Cookie): Unit = {} // nothing to do here
@@ -129,89 +165,102 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
     */
   override def version(datasetInfo: DatasetInfo, dataVersion: Long, cookie: Cookie, events: Iterator[Event[CT,CV]]): Cookie = {
     try {
+      val datasetInternalName = datasetInfo.internalName
+
       val oldCookie = FeedbackCookie.decode(cookie).getOrElse {
-        log.info("No existing cookie for dataset {}; going to resync.", datasetInfo.internalName)
-        throw ResyncSecondaryException(s"No cookie value for dataset ${datasetInfo.internalName}")
+        log.info("No existing cookie for dataset {}; going to resync.", datasetInternalName)
+        throw ResyncSecondaryException(s"No cookie value for dataset $datasetInternalName")
       }
 
       if (oldCookie.current.resync) {
-        log.info("Cookie for dataset {} for version {} specified to resync.", datasetInfo.internalName, dataVersion)
+        log.info("Cookie for dataset {} for version {} specified to resync.", datasetInternalName, dataVersion)
         throw ResyncSecondaryException("My cookie specified to resync!")
       }
 
       var result = cookie
       if (dataVersion != oldCookie.current.dataVersion.underlying
-        || (oldCookie.current.computationRetriesLeft > 0 && oldCookie.current.mutationScriptRetriesLeft > 0)) {
+        || (oldCookie.current.computationRetriesLeft > 0 && oldCookie.current.dataCoordinatorRetriesLeft > 0)) {
         // either we are not up to date on the data version or we still have retries left on the current version
         // note: we set the retries left to 0 once we have succeeded for the current version
         val toJValueFunc = toJValue(datasetInfo.obfuscationKey)
+        val fromJValueFunc = fromJValue(datasetInfo.obfuscationKey)
+        val currentContext = datasetContext(datasetInternalName, toJValueFunc, fromJValueFunc)
+
         val cookieSeed = oldCookie.copy(oldCookie.current.copy(DataVersion(dataVersion)), oldCookie.previous)
 
         // WARNING: this .foldLeft(.) has side effects!
-        val resultCookie = events.foldLeft(cookieSeed) { (newCookie, event) =>
+        case class FP(cookie: FeedbackCookie, columns: Set[UserColumnId])
+        val resultFP = events.foldLeft(FP(cookieSeed, Set.empty)) { case (FP(newCookie, newCompCols), event) =>
           event match {
             case ColumnCreated(columnInfo) =>
               val old = newCookie.current.strategyMap
-              val updated = columnInfo.computationStrategyInfo match {
+              val (updatedStrategyMap, updatedCompCols) = columnInfo.computationStrategyInfo match {
                 case Some(strategy) if computationHandlers.exists(_.matchesStrategyType(strategy.strategyType)) =>
-                  log.info("Computed column with strategy type {} added to dataset {}. Going to resync.", strategy.strategyType, datasetInfo.internalName)
-                  throw ResyncSecondaryException(s"New computed column for dataset ${datasetInfo.internalName}")
-                case _ => old
+                  (old + (columnInfo.id -> strategy), newCompCols + columnInfo.id)
+                case _ => (old, newCompCols)
               }
-              newCookie.copy(
+              FP(newCookie.copy(
                 current = newCookie.current.copy(
                   columnIdMap = newCookie.current.columnIdMap + (columnInfo.id -> columnInfo.systemId),
-                  strategyMap = updated
+                  strategyMap = updatedStrategyMap
                 )
-              )
+              ), updatedCompCols)
             case ColumnRemoved(columnInfo) =>
               val old = newCookie.current.strategyMap
-              val updated = columnInfo.computationStrategyInfo match {
+              val (updatedStrategyMap, updatedCompCols) = columnInfo.computationStrategyInfo match {
                 case Some(strategy) if computationHandlers.exists(_.matchesStrategyType(strategy.strategyType)) =>
-                  old - columnInfo.id
-                case _ => old
+                  (old - columnInfo.id, newCompCols - columnInfo.id)
+                case _ => (old, newCompCols)
               }
-              newCookie.copy(
+              FP(newCookie.copy(
                 current = newCookie.current.copy(
                   columnIdMap = newCookie.current.columnIdMap - columnInfo.id,
-                  strategyMap = updated
+                  strategyMap = updatedStrategyMap
                 )
-              )
+              ), updatedCompCols)
             case RowIdentifierSet(columnInfo) =>
-              newCookie.copy(
+              FP(newCookie.copy(
                 current = newCookie.current.copy(
                   primaryKey = columnInfo.id
                 )
-              )
+              ), newCompCols)
             case RowIdentifierCleared(columnInfo) =>
-              newCookie.copy(
+              FP(newCookie.copy(
                 current = newCookie.current.copy(
                   primaryKey = systemId
                 )
-              )
+              ), newCompCols)
             case SystemRowIdentifierChanged(columnInfo) =>
-              newCookie.copy(
+              FP(newCookie.copy(
                 current = newCookie.current.copy(
                   primaryKey = columnInfo.id
                 )
-              )
+              ), newCompCols)
             case WorkingCopyCreated(copyInfo) =>
-              newCookie.copy(
+              // Should be the first event in this version
+              if (newCompCols.nonEmpty) logErrorAndResync(notFirstEvent("WorkingCopyCreated"))
+              FP(newCookie.copy(
                 current = newCookie.current.copy(
                   copyNumber = CopyNumber(copyInfo.copyNumber)
                 ),
                 previous = Some(newCookie.current)
-              )
+              ), newCompCols)
             case WorkingCopyDropped =>
-              newCookie.copy(
+              // Should be the first event in this version
+              if (newCompCols.nonEmpty) logErrorAndResync(notFirstEvent("WorkingCopyCreated"))
+              FP(newCookie.copy(
                 current = newCookie.previous.getOrElse {
-                  log.info("No previous value in cookie for dataset {}. Going to resync.", datasetInfo.internalName)
-                  throw ResyncSecondaryException(s"No previous value in cookie for dataset ${datasetInfo.internalName}")
+                  log.info("No previous value in cookie for dataset {}. Going to resync.", datasetInternalName)
+                  throw ResyncSecondaryException(s"No previous value in cookie for dataset $datasetInternalName")
                 },
                 previous = None
-              )
+              ), newCompCols)
             case RowDataUpdated(operations) =>
               // in practice this should only happen once per data version
+              // flush handling of newly created computed columns
+              val updatedCookie =
+                currentContext(newCookie).flushColumnCreations(newCompCols)
+
               val toCompute = operations.toIterator.map { case op =>
                 op match {
                   case insert: Insert[CV] =>
@@ -223,14 +272,28 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
                 }
               }.filter(x => x.isDefined).map(x => x.get)
 
-              val context = new LocalContext(newCookie, toJValueFunc)
-              context.feedback(datasetInfo.internalName, toCompute)
+              log.info("Processing row update of dataset {} in version {}...", datasetInternalName, dataVersion)
+              FP(currentContext(updatedCookie).feedback(toCompute), Set.empty)
             case _ => // no-ops for us
-              newCookie
+              // flush handling of newly created computed columns
+              val updatedCookie =
+                currentContext(newCookie).flushColumnCreations(newCompCols)
+              FP(updatedCookie, Set.empty)
           }
         }
+        val resultCookie =
+          currentContext(resultFP.cookie).flushColumnCreations(resultFP.columns)
         result = FeedbackCookie.encode(resultCookie)
       }
+
+      def notFirstEvent(event: String) =
+        s"$event not the first event in version $dataVersion for dataset $datasetInternalName? Something is wrong!"
+
+      def logErrorAndResync(message: String): Nothing = {
+        log.error(message + " Going to resync.")
+        throw ResyncSecondaryException(message)
+      }
+
       result
     } catch {
       case resyncException: ResyncSecondaryException =>
@@ -239,7 +302,7 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
         throw replayLater
       case brokenDataset: BrokenDatasetSecondaryException =>
         throw brokenDataset
-      case error : Throwable =>
+      case error: Throwable =>
         log.error(s"An unexpected error has occurred: ${error.getMessage}\n{}", error.getStackTrace.toString)
         throw error
     }
@@ -262,7 +325,7 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
 
       val strategyMap = schema.toSeq.filter {
         case (_, colInfo) => colInfo.computationStrategyInfo.exists(cs => computationHandlers.exists(_.matchesStrategyType(cs.strategyType)))
-      }.map { case (_, colInfo) => (colInfo.id, colInfo.computationStrategyInfo.get)} .toMap
+      }.map { case (_, colInfo) => (colInfo.id, colInfo.computationStrategyInfo.get) }.toMap
 
       val cookieSchema = CookieSchema(
         dataVersion = DataVersion(copyInfo.dataVersion),
@@ -270,8 +333,8 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
         primaryKey = primaryKey,
         columnIdMap = columnIdMap,
         strategyMap = strategyMap,
-        computationRetriesLeft = retryLimit,
-        mutationScriptRetriesLeft = mutationScriptRetries,
+        computationRetriesLeft = computationRetryLimit,
+        dataCoordinatorRetriesLeft = dataCoordinatorRetryLimit,
         obfuscationKey = datasetInfo.obfuscationKey,
         resync = false
       )
@@ -279,12 +342,16 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
       var newCookie = FeedbackCookie(cookieSchema, None)
 
       val toJValueFunc = toJValue(datasetInfo.obfuscationKey)
+      val fromJValueFunc = fromJValue(datasetInfo.obfuscationKey)
       if (isLatestLivingCopy && newCookie.current.strategyMap.nonEmpty) {
         for {
           rws <- rows
         } {
-          val context = new LocalContext(newCookie, toJValueFunc)
-          newCookie = context.feedback(datasetInfo.internalName, rws.map(row => Row(row, None)), resync = true)
+          newCookie = datasetContext(
+            datasetInfo.internalName,
+            toJValueFunc,
+            fromJValueFunc
+          )(newCookie).feedback(rws.map { row => Row(row, None) }, resync = true)
         }
       }
 
@@ -294,7 +361,7 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
         throw replayLater
       case brokenDataset: BrokenDatasetSecondaryException =>
         throw brokenDataset
-      case error : Throwable =>
+      case error: Throwable =>
         // note: shouldn't ever throw a ResyncSecondaryException from inside resync
         log.error(s"An unexpected error has occurred: ${error.getMessage}\n{}", error.getStackTrace.toString)
         throw error
@@ -306,413 +373,6 @@ abstract class FeedbackSecondary[CT,CV] extends Secondary[CT,CV] {
    */
   // no-op: feedback secondaries don't need to feedback values for discarded/snapshotted copies
   override def dropCopy(datasetInfo: DatasetInfo, copyInfo: CopyInfo, cookie: Cookie, isLatestCopy: Boolean): Cookie = cookie
-
-  case class Row(data: secondary.Row[CV], oldData: Option[secondary.Row[CV]])
-
-  private class LocalContext(feedbackCookie: FeedbackCookie, toJValueFunc: CV => JValue) {
-
-    val cookie = feedbackCookie.current
-
-    def mergeWith[A, B](xs: Map[A, B], ys: Map[A, B])(f: (B, B) => B): Map[A, B] = {
-      ys.foldLeft(xs) { (combined, yab) =>
-        val (a,yb) = yab
-        val newB = combined.get(a) match {
-          case None => yb
-          case Some(xb) => f(xb, yb)
-        }
-        combined.updated(a, newB)
-      }
-    }
-
-    // this may throw a ResyncSecondaryException, a ReplayLaterSecondaryException, or a BrokenDatasetSecondaryException
-    def feedback(datasetInternalName: String, rows: Iterator[Row], resync: Boolean = false): FeedbackCookie = {
-      val width = cookie.columnIdMap.size
-      val size = batchSize(width)
-
-      log.info("Processing row update of dataset {} in version {} with batch_size = {}",
-        datasetInternalName, cookie.dataVersion.underlying.toString, size.toString)
-
-      def b(retriesLeft: Int, message: String): Int = {
-        if (retriesLeft == 0) throw new BrokenDatasetSecondaryException(message)
-        retriesLeft
-      }
-
-      var count = 0
-      try {
-        rows.grouped(size).foreach { batchSeq =>
-          val batch: Seq[Row] = batchSeq.toIndexedSeq
-          count += 1
-          val updates = computationHandlers.foldLeft(Map.empty[Int, Map[UserColumnId, CV]]) { (currentUpdates, computationHandler) =>
-            val currentRows = batch.toArray
-            for((idx, upds) <- currentUpdates) {
-              val currentRow = MutableColumnIdMap(currentRows(idx).data)
-              for((cid, cv) <- upds) {
-                currentRow(cookie.columnIdMap(cid)) = cv
-              }
-              currentRows(idx) = currentRows(idx).copy(data = currentRow.freeze())
-            }
-            val newUpdates = computeUpdates(computationHandler, currentRows)
-            mergeWith(currentUpdates, newUpdates)(_ ++ _)
-          }
-          val jsonUpdates = updates.valuesIterator.map { updates =>
-            JsonEncode.toJValue(updates.mapValues(toJValueFunc))
-          }
-          writeMutationScript(jsonUpdates) match {
-            case Some(script) =>
-              val result = postMutationScript(datasetInternalName, script)
-              result match {
-                case Success =>
-                  log.info("Finished batch {} of approx. {} rows", count, size)
-                  statusMonitor.update(datasetInternalName, cookie.dataVersion, size, count)
-                case ftddc@FailedToDiscoverDataCoordinator =>
-                  log.warn("Failed to discover data-coordinator; going to request to have this dataset replayed later")
-                  // we will retry this "indefinitely"; do not decrement retries left
-                  throw ReplayLaterSecondaryException(ftddc.english, FeedbackCookie.encode(feedbackCookie.copy(current = cookie.copy(resync = resync))))
-                case ddb@DataCoordinatorBusy =>
-                  log.info("Received a 409 from data-coordinator; going to request to have this dataset replayed later")
-                  // we will retry this "indefinitely"; do not decrement retries left
-                  throw ReplayLaterSecondaryException(ddb.english, FeedbackCookie.encode(feedbackCookie.copy(current = cookie.copy(resync = resync))))
-                case ddne@DatasetDoesNotExist =>
-                  log.info("Completed updating dataset {} to version {} early: {}", datasetInternalName, cookie.dataVersion.underlying.toString, ddne.english)
-                  statusMonitor.remove(datasetInternalName, cookie.dataVersion, count)
-
-                  // nothing more to do here
-                  return feedbackCookie.copy(
-                    current = cookie.copy(
-                      computationRetriesLeft = 0,
-                      mutationScriptRetriesLeft = 0,
-                      resync = false
-                    )
-                  )
-                case schemaChange =>
-                  log.info("A schema change occurred breaking my upsert: {}; going to start a resync...", schemaChange.english)
-                  throw ResyncSecondaryException(s"A schema change occurred breaking my upsert: ${schemaChange.english}")
-              }
-            case None =>
-              log.info("Batch {} had no rows to update of approx. {} rows; no script posted.", count, size)
-              statusMonitor.update(datasetInternalName, cookie.dataVersion, size, count)
-          }
-        }
-      } catch {
-        case ComputationFailure(reason, cause) =>
-          // Some failure has occurred in computation; we will only retry these exceptions so many times
-          val gaveUp = "Gave up replaying updates after too many failed computation attempts"
-          val newCookie = feedbackCookie.copy(
-            current = cookie.copy(
-              computationRetriesLeft = b(cookie.computationRetriesLeft - 1, gaveUp), // decrement retries
-              mutationScriptRetriesLeft = mutationScriptRetries, // reset mutation script retries
-              resync = resync
-            )
-          )
-          throw ReplayLaterSecondaryException(reason, FeedbackCookie.encode(newCookie))
-        case FeedbackFailure(reason, cause) =>
-          // We failed to post our mutation script to data-coordinator for some reason
-          val gaveUp = "Gave up replaying updates after too many failed mutation script attempts"
-          val newCookie = feedbackCookie.copy(
-            current = cookie.copy(
-              computationRetriesLeft = retryLimit, // reset computation retries
-              mutationScriptRetriesLeft = b(cookie.mutationScriptRetriesLeft - 1, gaveUp), // decrement retries
-              resync = resync
-            )
-          )
-          throw ReplayLaterSecondaryException(reason, FeedbackCookie.encode(newCookie))
-      }
-      log.info("Completed row update of dataset {} in version {} after batch: {}",
-        datasetInternalName, cookie.dataVersion.underlying.toString, count.toString)
-      statusMonitor.remove(datasetInternalName, cookie.dataVersion, count)
-
-      // success!
-      feedbackCookie.copy(
-        current = cookie.copy(
-          computationRetriesLeft = 0,
-          mutationScriptRetriesLeft = 0,
-          resync = false
-        )
-      )
-    }
-
-    // this may throw a ComputationFailure exception
-    private def computeUpdates(computationHandler: ComputationHandler[CT,CV], rows: IndexedSeq[Row]): Map[Int,Map[UserColumnId, CV]] = {
-      val perDatasetData = computationHandler.setupDataset(cookie)
-      val perColumnData = cookie.strategyMap.toSeq.collect {
-        case (targetCol, strat) if computationHandler.matchesStrategyType(strat.strategyType) =>
-          computationHandler.setupColumn(perDatasetData, strat, targetCol)
-      }
-      val toCompute = rows.iterator.zipWithIndex.flatMap { case (row, index) =>
-        val rcis =
-          perColumnData.flatMap { columnData =>
-            // don't compute if there has been to change to the source columns
-            if (noChange(row, columnData.strategy.sourceColumnIds))
-              None
-            else
-              Some(computationHandler.setupCell(columnData, row.data))
-          }
-        if(rcis.isEmpty) Iterator.empty
-        else Iterator.single(index -> rcis)
-      }.toMap
-
-      val results = computationHandler.compute(toCompute)
-
-      results.flatMap { case (rowIdx, updates) =>
-        val row = rows(rowIdx)
-        val filtered = updates.filter { case (colId: UserColumnId, value) =>
-          extractCV(row.data, colId) != Some(value) // don't update to current value
-        }
-        val rowId = extractCV(row.data, cookie.primaryKey) match {
-          case None => throw new Exception(s"Cannot find value for primary key ${cookie.primaryKey} in row: $row!")
-          case Some(other) => other
-        }
-        if (filtered.nonEmpty) {
-          val newRow = Map(
-            cookie.primaryKey -> rowId
-          ) ++ filtered.map { case (id, value) => (id, value)}.toMap
-          Some(rowIdx -> newRow)
-        } else {
-          None
-        }
-      }
-    }
-
-    private def noChange(row: Row, columns: Seq[UserColumnId]): Boolean = row.oldData match {
-      case Some(old) =>
-        columns.forall { id =>
-          val internal = cookie.columnIdMap(id)
-          row.data(internal) == old(internal) // safe because updates contain _all_ row values (and this must be one)
-        }
-      case None => false
-    }
-
-    private def extractCV(row: secondary.Row[CV], userId: UserColumnId): Option[CV] = {
-      val internal = cookie.columnIdMap(userId)
-      row.get(internal)
-    }
-
-    // commands for mutation scripts
-    val commands = Seq(
-      JObject(Map(
-        "c" -> JString("normal"),
-        "user" -> JString(user)
-      )),
-      JObject(Map(
-        "c" -> JString("row data"),
-        "update_only" -> JBoolean.canonicalTrue,
-        "nonfatal_row_errors" -> JArray(Array(JString("insert_in_update_only")))
-      ))
-    )
-
-    private def writeMutationScript(rowUpdates: Iterator[JValue]): Option[JArray] = {
-      if (!rowUpdates.hasNext) None
-      else Some(JArray(commands ++ rowUpdates))
-    }
-
-    val UpdateDatasetDoesNotExist = "update.dataset.does-not-exist"
-    val UpdateRowUnknownColumn = "update.row.unknown-column"
-    val UpdateRowPrimaryKeyNonexistentOrNull = "update.row.primary-key-nonexistent-or-null"
-
-    private def fail(message: String): Nothing = {
-      log.error(message)
-      throw FeedbackFailure(message)
-    }
-
-    private def fail(message: String, cause: Throwable): Nothing = {
-      log.error(message)
-      throw FeedbackFailure(message, cause)
-    }
-
-    private def retrying[T](actions: => T, remainingAttempts: Int = internalMutationScriptRetries): T = {
-      val failure = try {
-        return actions
-      } catch {
-        case e: IOException => e
-        case e: HttpClientException => e
-        case e: JsonReaderException => e
-      }
-
-      log.info("Failure occurred while posting mutation script: {}", failure.getMessage)
-      if (remainingAttempts > 0) retrying(actions, remainingAttempts - 1)
-      else fail(s"Ran out of retry attempts after failure: ${failure.getMessage}", failure)
-    }
-
-    sealed abstract class MutationScriptResult {
-      def english: String
-    }
-
-    case object Success extends MutationScriptResult {
-      val english = "Successfully upserted rows"
-    }
-
-    case object FailedToDiscoverDataCoordinator extends MutationScriptResult {
-      val english = "Failed to discover data-coordinator host and port"
-    }
-
-    case object DataCoordinatorBusy extends MutationScriptResult {
-      val english = "Data-coordinator responded with 409"
-    }
-
-    case object DatasetDoesNotExist extends MutationScriptResult {
-      val english = "Dataset does not exist"
-    }
-
-    case class PrimaryKeyColumnDoesNotExist(id: UserColumnId) extends MutationScriptResult {
-      val english = s"Primary key column ${id.underlying} does not exist"
-    }
-
-    case class TargetColumnDoesNotExist(id: UserColumnId) extends MutationScriptResult {
-      val english = s"Target column ${id.underlying} does not exist"
-    }
-
-    case object PrimaryKeyColumnHasChanged extends MutationScriptResult {
-      val english = "The primary key column has changed"
-    }
-
-    case class ErrorResponse(errorCode: String, data: JObject)
-
-    implicit val erCodec = AutomaticJsonCodecBuilder[ErrorResponse]
-
-    sealed class Response
-
-    case class Upsert(typ: String, id: String, ver: String) extends Response
-
-    case class NonfatalError(typ: String, err: String, id: Option[String]) extends Response
-
-    implicit val upCodec = AutomaticJsonCodecBuilder[Upsert]
-    implicit val neCodec = AutomaticJsonCodecBuilder[NonfatalError]
-    implicit val reCodec = SimpleHierarchyCodecBuilder[Response](NoTag).branch[Upsert].branch[NonfatalError].build
-
-    def datasetEndpoint(datasetInternalName: String): Option[String] = {
-      datasetInternalName.lastIndexOf('.') match {
-        case -1 =>
-          log.error("Could not extract data-coordinator instance name from dataset: {}", datasetInternalName)
-          throw new Exception(s"Could not extract data-coordinator instance name from dataset: $datasetInternalName")
-        case n =>
-          hostAndPort(datasetInternalName.substring(0, n)) match {
-            case Some((host, port)) => Some(s"http://$host:$port/dataset/$datasetInternalName")
-            case None => None
-          }
-      }
-    }
-
-    // this may throw a FeedbackFailure exception
-    private def postMutationScript(datasetInternalName: String, script: JArray): MutationScriptResult = {
-      val endpoint = datasetEndpoint(datasetInternalName).getOrElse(return FailedToDiscoverDataCoordinator)
-      val builder = RequestBuilder(new java.net.URI(endpoint))
-
-      def body = JValueEventIterator(script)
-
-      retrying[MutationScriptResult] {
-        val start = System.nanoTime()
-        httpClient.execute(builder.json(body)).run { resp =>
-
-          def logContentTypeFailure(v: => JValue): JValue =
-            try {
-              v
-            } catch {
-              case e: ContentTypeException =>
-                log.warn("The response from data-coordinator was not a valid JSON content type! The body we sent was: {}", body)
-                fail("Unable to understand data-coordinator's response", e) // no retry here
-            }
-
-          resp.resultCode match {
-            case 200 =>
-              // success! ... well maybe...
-              val end = System.nanoTime()
-              log.info("Posted mutation script with {} row updates in {}ms", script.length - 2, (end - start) / 1000000)
-              JsonDecode.fromJValue[JArray](logContentTypeFailure(resp.jValue())) match {
-                case Right(response) =>
-                  assert(response.elems.length == 1, "Response contains more than one element")
-                  JsonDecode.fromJValue[JArray](response.elems.head) match {
-                    case Right(results) =>
-                      assert(results.elems.length == script.elems.length - 2, "Did not get one result for each upsert command that was sent")
-                      val rows = script.elems.slice(2, script.elems.length)
-                      results.elems.zip(rows).foreach { case (result, row) =>
-                        JsonDecode.fromJValue[Response](result) match {
-                          case Right(Upsert("update", _, _)) => // yay!
-                          case Right(NonfatalError("error", "insert_in_update_only", Some(id))) =>
-                            val JObject(fields) = JsonDecode.fromJValue[JObject](row).right.get // I just encoded this from a JObject
-                            val rowId = JsonDecode.fromJValue[JString](fields(cookie.primaryKey.underlying)).right.get.string
-                            if (rowId != id) return PrimaryKeyColumnHasChanged // else the row has been deleted
-                          case Right(other) =>
-                            fail(s"Unexpected response in array: ${other.toString}")
-                          case Left(e) =>
-                            fail(s"Unable to interpret result in array: ${e.english}")
-                        }
-                      }
-                      Success
-                    case Left(e) =>
-                      fail(s"Row data results from data-coordinator was not an array: ${e.english}")
-                  }
-                case Left(e) =>
-                  fail(s"Response from data-coordinator was not an array: ${e.english}")
-              }
-            case 400 =>
-              JsonDecode.fromJValue[ErrorResponse](logContentTypeFailure(resp.jValue())) match {
-                case Right(response) =>
-                  response.errorCode match {
-                    // { "errorCode" : "update.row.unknown-column"
-                    // , "data" : { "commandIndex" : 1, "commandSubIndex" : XXX, "dataset" : "XXX.XXX", "column" : "XXXX-XXXX"
-                    // }
-                    case UpdateRowUnknownColumn =>
-                      response.data.get("column") match {
-                        case Some(JString(id)) =>
-                          if (id == cookie.primaryKey.underlying)
-                            PrimaryKeyColumnDoesNotExist(cookie.primaryKey)
-                          else
-                            TargetColumnDoesNotExist(new UserColumnId(id))
-                        case Some(other) =>
-                          fail(s"Unable to interpret error response from data-coordinator for status 400: $response")
-                        case None =>
-                          fail(s"Unable to interpret error response from data-coordinator for status 400: $response")
-                      }
-                    // { "errorCode" : "update.row.primary-key-nonexistent-or-null"
-                    // , "data" : { "commandIndex" : 1, "dataset" : "XXX.XXX"
-                    // }
-                    case UpdateRowPrimaryKeyNonexistentOrNull =>
-                      PrimaryKeyColumnHasChanged
-                    case errorCode =>
-                      fail(s"Received an unexpected error code from data-coordinator for status 400: $errorCode")
-                  }
-                case Left(e) =>
-                  fail(s"Unable to interpret error response from data-coordinator for status 400: ${e.english}")
-              }
-            case 404 =>
-              // { "errorCode" : "update.dataset.does-not-exist"
-              // , "data" : { "dataset" : "XXX.XXX, "data" : { "commandIndex" : 0 }
-              // }
-              JsonDecode.fromJValue[ErrorResponse](logContentTypeFailure(resp.jValue())) match {
-                case Right(response) =>
-                  response.errorCode match {
-                    case UpdateDatasetDoesNotExist => // awesome!
-                      DatasetDoesNotExist
-                    case errorCode => // awesome!
-                      fail(s"Received an unexpected error code from data-coordinator for status 404: $errorCode")
-                  }
-                case Left(e) =>
-                  fail(s"Unable to interpret error response from data-coordinator for status 404: ${e.english}")
-              }
-            case 409 =>
-              // come back later!
-              DataCoordinatorBusy // no retry
-            case other =>
-              if (other == 500) {
-                log.warn("Scream! 500 from data-coordinator! Going to retry; my mutation script was: {}",
-                  JsonUtil.renderJson(script, pretty = false)
-                )
-              }
-              // force a retry
-              throw new IOException(s"Unexpected result code $other from data-coordinator")
-          }
-        }
-      }
-    }
-  }
-
-  // to be initially thrown by postMutationScript
-  case class FeedbackFailure(reason: String, cause: Throwable) extends Exception(reason, cause)
-
-  object FeedbackFailure {
-
-    def apply(reason: String): FeedbackFailure = FeedbackFailure(reason, null)
-  }
 }
 
 /**

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/RequestFailure.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/RequestFailure.scala
@@ -1,0 +1,41 @@
+package com.socrata.datacoordinator.secondary.feedback
+
+import com.socrata.datacoordinator.id.UserColumnId
+
+sealed abstract class RequestFailure {
+  def english: String
+}
+
+case object FailedToDiscoverDataCoordinator extends RequestFailure {
+  val english = "Failed to discover data-coordinator host and port"
+}
+
+case object DataCoordinatorBusy extends RequestFailure {
+  val english = "Data-coordinator responded with 409"
+}
+
+case object DatasetDoesNotExist extends RequestFailure {
+  val english = "Dataset does not exist"
+}
+
+sealed abstract class SchemaFailure {
+  def english: String
+}
+
+sealed abstract class UpdateSchemaFailure extends SchemaFailure
+
+case class PrimaryKeyColumnDoesNotExist(id: UserColumnId) extends UpdateSchemaFailure {
+  val english = s"Primary key column ${id.underlying} does not exist"
+}
+
+case class TargetColumnDoesNotExist(id: UserColumnId) extends UpdateSchemaFailure {
+  val english = s"Target column ${id.underlying} does not exist"
+}
+
+case object PrimaryKeyColumnHasChanged extends UpdateSchemaFailure {
+  val english = "The primary key column has changed"
+}
+
+case class ColumnsDoNotExist(columns: Set[UserColumnId]) extends SchemaFailure {
+  val english = s"Columns ${columns.map(_.underlying)} do not exist"
+}

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/instance/FeedbackSecondaryInstance.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/instance/FeedbackSecondaryInstance.scala
@@ -14,7 +14,7 @@ import org.apache.curator.x.discovery.{strategies, ServiceDiscoveryBuilder}
 
 abstract class FeedbackSecondaryInstance(config: FeedbackSecondaryInstanceConfig) extends FeedbackSecondary[SoQLType, SoQLValue] {
 
-  log.info("Configuration:\n" + config.debugString)
+  log.debug("Configuration:\n" + config.debugString)
 
   private val resourceScope = new ResourceScope("feedback secondary")
 
@@ -59,12 +59,14 @@ abstract class FeedbackSecondaryInstance(config: FeedbackSecondaryInstanceConfig
 
   override val baseBatchSize: Int = config.baseBatchSize
 
-  override val internalMutationScriptRetries: Int = config.mutationScriptRetries
+  override val dataCoordinatorRetryLimit: Int = config.dataCoordinatorRetries
+  override val internalDataCoordinatorRetryLimit: Int = config.internalDataCoordinatorRetries
 
-  override val mutationScriptRetries: Int = config.mutationScriptRetries
+  override val repFor = SoQLValueRepFor
+  override val repFrom = SoQLValueRepFrom
 
-  override val repFor = SoQLValueRep
   override val typeFor = SoQLTypeFor
+  override val typeFromJValue = SoQLTypeFromJValue
 
   override val statusMonitor: StatusMonitor = new DummyStatusMonitor // TODO: replace with status monitor connected to ISS
 

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/instance/config/FeedbackSecondaryInstanceConfig.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/instance/config/FeedbackSecondaryInstanceConfig.scala
@@ -15,10 +15,10 @@ class FeedbackSecondaryInstanceConfig(config: Config, root: String) extends Conf
 
   val baseBatchSize = getInt("base-batch-size")
   val computationRetries = getInt("computation-retries")
-  val internalMutationScriptRetries = getInt("internal-mutation-script-retries")
-  val mutationScriptRetries = getInt("mutation-script-retries")
   val curator = getConfig("curator", new CuratorConfig(_, _))
   val dataCoordinatorService = getString("data-coordinator-service")
+  val dataCoordinatorRetries = getInt("data-coordinator-retries")
+  val internalDataCoordinatorRetries = getInt("internal-data-coordinator-retries")
 
   val debugString = config.root.render()
 }


### PR DESCRIPTION
Export source column rows from core to compute values
for newly created computed columns:
 * Changes retry limit config names
 * Changes the name of cookie field