### PR TITLE
Add `unsafeCreateDatasetAllocatingSystemId`

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
@@ -91,6 +91,12 @@ trait BackupDatasetMap[CT] extends DatasetMapWriter[CT] with `-impl`.BaseDataset
                           localeName: String,
                           obfuscationKey: Array[Byte]): DatasetInfo
 
+  /** Creates a dataset with the specified attributes
+    * @note Using this carelessly can get you into trouble.  In particular, this
+    *       newly created dataset will have NO copies attached. */
+  def unsafeCreateDatasetAllocatingSystemId(localeName: String,
+                                            obfuscationKey: Array[Byte]): DatasetInfo
+
   /** Reloads a dataset with the specified attributes, including CLEARING ALL COPIES.
     * @note Using this carelessly can get you into trouble.  It is intended to be used
     *       for resyncing only.  The resulting dataset object will have NO copies. */

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.50"
+version in ThisBuild := "3.0.51"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.0.51"
+version in ThisBuild := "3.0.52-SNAPSHOT"


### PR DESCRIPTION
PG secondary needs to use this when initially creating its dataset, so
that it can create the correct initial copy when it is not copy #1.