### PR TITLE
EN-5687: add index on secondary_manifest.went_out_of_sync_at

### DIFF
--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20160823-add-went-out-of-sync-at-index.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20160823-add-went-out-of-sync-at-index.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="mschneider" id="20160823-add-went-out-of-sync-at-index">
+        <sql>
+            CREATE INDEX secondary_manifest_went_out_of_sync_at ON secondary_manifest (went_out_of_sync_at)
+        </sql>
+        <rollback>
+            DROP INDEX secondary_manifest_went_out_of_sync_at
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -24,6 +24,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20160420-add-copy-map-table-modifiers.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20160420-add-pending-drop-column.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20160422-drop-latest-secondary-lifecycle-stage-column.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20160823-add-went-out-of-sync-at-index.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>


### PR DESCRIPTION
Hopefully this will help the initial claim of a dataset work better;
this query is involved in assorted deadlocks. Note that this is not
expected to fix the deadlock issue on its own, but this query being
inefficient isn't helping that problem.