### PR TITLE
EN-5578: Expand `/secondaries-of-dataset` endpoint

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/SecondariesOfDatasetResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/SecondariesOfDatasetResource.scala
@@ -8,9 +8,14 @@ import com.socrata.http.server.responses._
 import com.socrata.http.server.implicits._
 
 @JsonKeyStrategy(Strategy.Underscore)
-case class SecondariesOfDatasetResult(truthVersion: Long,
+case class SecondariesOfDatasetResult(truthVersion: Long, // TODO: remove this field once soda-fountain no-longer uses it
+                                      latestVersion: Long,
+                                      publishedVersion: Option[Long],
+                                      unpublishedVersion: Option[Long],
                                       secondaries: Map[String, Long],
-                                      feedbackSecondaries: Set[String])
+                                      feedbackSecondaries: Set[String],
+                                      groups: Map[String, Set[String]]
+                                      )
 
 object SecondariesOfDatasetResult {
 

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20161006-add-column-group-name.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20161006-add-column-group-name.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="Alexa Rust" id="20161006-add-column-group-name">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="secondary_stores_config" columnName="group_name"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="secondary_stores_config">
+            <column name="group_name" type="VARCHAR(40)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -24,6 +24,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20160420-add-copy-map-table-modifiers.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20160420-add-pending-drop-column.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20160422-drop-latest-secondary-lifecycle-stage-column.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20161006-add-column-group-name.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryStoresConfig.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryStoresConfig.scala
@@ -55,4 +55,23 @@ class SqlSecondaryStoresConfig(conn: Connection, timingReport: TimingReport) ext
       t("update-next-runtime", "store-id" -> storeId)(stmt.execute())
     }
   }
+
+  def group(storeId: String): Option[String] = {
+    val sql = """
+      SELECT group_name
+        FROM secondary_stores_config
+       WHERE store_id = ?""".stripMargin
+
+    for {
+      stmt <- managed(conn.prepareStatement(sql))
+      _ <- unmanaged(stmt.setString(1, storeId))
+      rs <- managed(stmt.executeQuery())
+    } yield {
+      if(rs.next()) {
+        Option(rs.getString("group_name"))
+      } else {
+        None
+      }
+    }
+  }
 }


### PR DESCRIPTION
Additions to `/secondaries-of-dataset` endpoint:
 * `latest` data-version
 * `published` data-version
 * `unpublished` data-version
 * `groups` - a map from `group_name` to the set of
   `store_id`s (only the `store_id`s that the dataset
   is replicated to)

Migration: Adds a column `group_name`
to the `secondary_stores_config` table.