### PR TITLE
EN-11190: Create index on secondary_manifest for efficient querying by secondary watcher.

### DIFF
--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20161014-add-secondary-manifest-queue-index.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20161014-add-secondary-manifest-queue-index.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="marcs" id="20161014-add-secondary-manifest-queue-index">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                select count(*) from pg_indexes where tablename='secondary_manifest' and indexname='secondary_manifest_is_a_queue'
+            </sqlCheck>
+        </preConditions>
+        <sql>
+            CREATE INDEX secondary_manifest_is_a_queue ON secondary_manifest (
+                store_id, (broken_at IS NULL), next_retry, (latest_data_version > latest_secondary_data_version OR pending_drop = true), claimed_at, went_out_of_sync_at
+            ) WHERE
+                broken_at IS NULL
+                AND (latest_data_version > latest_secondary_data_version
+                OR pending_drop = true                                                        )
+        </sql>
+        <rollback>
+            DROP INDEX secondary_manifest_is_a_queue
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -25,6 +25,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20160420-add-pending-drop-column.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20160422-drop-latest-secondary-lifecycle-stage-column.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20161006-add-column-group-name.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20161014-add-secondary-manifest-queue-index.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>


### PR DESCRIPTION
It isn't perfect because we don't quite express things in the right
way in secondary_manifest, but is much improved.  This normally
doesn't make a big difference, but is very very significant if you have
old transactions preventing vacuuming of secondary_manifest combined with a
lot of updates.