### PR TITLE
EN-4308: Improve secondary-watcher claim releasing

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
@@ -1,7 +1,7 @@
 package com.socrata.datacoordinator.secondary
 package sql
 
-import java.sql.{Types, Connection}
+import java.sql.{Types, Connection, SQLException}
 import java.util.UUID
 
 import com.rojoma.simplearm.util._
@@ -15,6 +15,8 @@ import com.socrata.datacoordinator.util.PostgresUniqueViolation
 import scala.concurrent.duration.FiniteDuration
 
 class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
+  private val log = org.slf4j.LoggerFactory.getLogger(classOf[SqlSecondaryManifest])
+
   def readLastDatasetInfo(storeId: String, datasetId: DatasetId): Option[(Long, Option[String])] =
     using(conn.prepareStatement("SELECT latest_secondary_data_version, cookie FROM secondary_manifest WHERE store_id = ? AND dataset_system_id = ?")) { stmt =>
       stmt.setString(1, storeId)
@@ -208,6 +210,50 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
   }
 
   def releaseClaimedDataset(job: SecondaryRecord): Unit = {
+    // set savepoint
+    val savepoint = conn.setSavepoint()
+
+    // retrying with rollback to savepoint
+    def retrying(backoff: Int = 5): Unit = {
+      if (backoff > 300000) { // > 5 minutes
+        log.error("Ran out of retries; failed to release claim on dataset {} in secondary {}!",
+          job.datasetId, job.storeId)
+        throw new Exception("Ran out of retries; Failed to release claim on dataset!")
+      }
+
+      try {
+        log.trace("Attempting to release claim on dataset for job: {}.", job)
+        releaseClaimedDatasetUnsafe(job)
+      } catch {
+        case e: SQLException =>
+          log.warn("Unexpected sql exception while releasing claim on dataset {} in secondary {}",
+            job.datasetId.asInstanceOf[AnyRef], job.storeId, e)
+          conn.rollback(savepoint)
+          Thread.sleep(backoff)
+          retrying(2 * backoff)
+      } finally {
+        try {
+          conn.releaseSavepoint(savepoint)
+        } catch {
+          case e: SQLException =>
+            // Ignore; this means one of two things:
+            // * the server is in an unexpected "transaction aborted" state, so all we
+            //    can do is roll back (either to another, earlier savepoint or completely)
+            //    and either way this savepoint will be dropped implicitly
+            // * things have completely exploded and nothing can be done except
+            //    dropping the connection altogether.
+            // The latter could happen if this finally block is being run because
+            // this method is exiting normally, but in that case whatever we do next
+            // will fail so meh.  Just log it and continue.
+            log.warn("Unexpected exception releasing savepoint", e)
+        }
+      }
+    }
+
+    retrying()
+  }
+
+  private def releaseClaimedDatasetUnsafe(job: SecondaryRecord): Unit = {
     using(conn.prepareStatement(
       """UPDATE secondary_manifest
         |SET claimed_at = NULL
@@ -221,7 +267,6 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
       stmt.executeUpdate()
     }
   }
-
 
   def markSecondaryDatasetBroken(job: SecondaryRecord): Unit = {
     using(conn.prepareStatement(

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -220,7 +220,7 @@ class SecondaryWatcherClaimManager(dsInfo: DSInfo, claimantId: UUID, claimTimeou
 
   // A claim on a dataset on the secondary manifest expires after claimTimeout.
   //
-  // To maintain our claims on a dataset we will update the claimed_at timestamp every
+  // To maintain our claim on a dataset we will update the claimed_at timestamp every
   // updateInterval = claimTimeout / 4 < claimTimeout, therefore as we update our claims on a shorter interval
   // than that they timeout, as long as our instance is running we will not lose our claims.
   //
@@ -269,11 +269,11 @@ class SecondaryWatcherClaimManager(dsInfo: DSInfo, claimantId: UUID, claimTimeou
           log.warn("Failed to update claimed_at time before timing-out.")
         }
       }
-      val failureTimeout = System.currentTimeMillis() + updateInterval.toMillis
-      retryingUpdate(failureTimeout) // initial timeout is .5 second with a backoff of 2 * timeout
-      val remainingTime = math.max(failureTimeout - System.currentTimeMillis(), 0.toLong)
+      val failureTimeoutMillis = System.currentTimeMillis() + updateInterval.toMillis
+      retryingUpdate(failureTimeoutMillis) // initial timeout is .5 second with a backoff of 2 * timeout
+      val remainingTimeMillis = math.max(failureTimeoutMillis - System.currentTimeMillis(), 0.toLong)
 
-      done = awaitEither(finished, remainingTime) // await for the rest of the updateInterval
+      done = awaitEither(finished, remainingTimeMillis) // await for the rest of the updateInterval
     }
   }
 

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -205,13 +205,8 @@ object SecondaryWatcherClaimManager {
     log.debug(s"Removed dataset {} for store $storeId from our working set which is now {}.", datasetId, workingSet)
   }
 
-  private def workingSetStr: Option[String] =
-    if (workingSet.nonEmpty) Some(workingSet.map(_._2).mkString(",")) else None // get the dataset ids
-
-  def andInWorkingSetSQL: String = workingSetStr match {
-    case Some(ids) => s" AND dataset_system_id IN ($ids)"
-    case None => ""
-  }
+  def andInWorkingSetSQL: String = workingSet.headOption.map { _ =>
+    workingSet.map(_._2).mkString(" AND dataset_system_id IN (", ",", ")") }.getOrElse("")
 }
 
 class SecondaryWatcherClaimManager(dsInfo: DSInfo, claimantId: UUID, claimTimeout: FiniteDuration) {


### PR DESCRIPTION
Add retry logic around releasing claims in secondary-watcher.
