### PR TITLE
EN-11329: Fix 400s from DC for posting deleted rows

### DIFF
--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/DataCoordinatorClient.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/DataCoordinatorClient.scala
@@ -241,7 +241,7 @@ class DataCoordinatorClient[CT,CV](httpClient: HttpClient,
           results.elems.zip(rows).foreach { case (result, row) =>
             JsonDecode.fromJValue[Response](result) match {
               case Right(Upsert("update", _, _)) => // yay!
-              case Right(NonfatalError("error", "insert_in_update_only", Some(id))) =>
+              case Right(NonfatalError("error", nonfatalError, Some(id))) if nonfatalError == "insert_in_update_only" ||  nonfatalError == "no_such_row_to_update" =>
                 val JObject(fields) = JsonDecode.fromJValue[JObject](row).right.get // I just encoded this from a JObject
                 val rowId = JsonDecode.fromJValue[JString](fields(cookie.primaryKey.underlying)).right.get.string
                 if (rowId != id) return Some(PrimaryKeyColumnHasChanged) // else the row has been deleted

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
@@ -126,7 +126,7 @@ class FeedbackContext[CT,CV](user: String,
   // commands for mutation scripts
   private val commands: Seq[JValue] =
     j"""[ { "c" : "normal", "user" : $user }
-        , { "c" : "row data", "update_only" : true, "nonfatal_row_errors" : [ "insert_in_update_only" ] }
+        , { "c" : "row data", "update_only" : true, "nonfatal_row_errors" : [ "insert_in_update_only", "no_such_row_to_update" ] }
         ]""".toSeq
 
   private def writeMutationScript(rowUpdates: Iterator[JValue]): Option[JArray] = {


### PR DESCRIPTION
Use the `"no_such_row_to_update"` non-fatal error option
in mutation scripts.