### PR TITLE
Hack week: Secondary-watcher sends messages

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryInfo.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryInfo.scala
@@ -8,4 +8,5 @@ trait SecondaryStoresConfig {
   def lookup(storeId: String): Option[SecondaryConfigInfo]
   def create(secondaryInfo: SecondaryConfigInfo): SecondaryConfigInfo
   def updateNextRunTime(storeId: String, newNextRunTime: DateTime): Unit
+  def group(storeId: String): Option[String]
 }

--- a/project/CoordinatorLib.scala
+++ b/project/CoordinatorLib.scala
@@ -28,8 +28,10 @@ object CoordinatorLib {
       "org.liquibase" % "liquibase-plugin" % "1.9.5.0",
       "org.postgresql" % "postgresql" % "9.3-1102-jdbc41", // we do use postgres-specific features some places
       "org.xerial.snappy" % "snappy-java" % "1.1.0-M3",
+      "com.socrata" %% "eurybates" % "1.0.4",
+      "org.apache.activemq" % "activemq-core" % "5.7.0" exclude("org.apache", "commons.logging") exclude("commons-logging", "commons-logging") exclude("org.springframework", "spring-context"),
 
-      TestDeps.scalaCheck % "test,it",
+       TestDeps.scalaCheck % "test,it",
       TestDeps.slf4jSimple % "test,it",
       TestDeps.h2 % "test,it"
     ),

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/Producer.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/Producer.scala
@@ -1,0 +1,70 @@
+package com.socrata.datacoordinator.secondary
+
+import java.util.{Properties, UUID}
+import java.util.concurrent.Executor
+
+import com.rojoma.json.v3.codec.JsonEncode
+import com.rojoma.simplearm.{SimpleArm, Managed}
+import com.socrata.eurybates
+import com.socrata.eurybates.ServiceName
+import com.socrata.eurybates.zookeeper.ServiceConfiguration
+import com.socrata.thirdparty.typesafeconfig.ConfigClass
+import com.socrata.zookeeper.ZooKeeperProvider
+import com.typesafe.config.Config
+import org.slf4j.LoggerFactory
+
+class Producer(sourceId: String, instance: String, zkp: ZooKeeperProvider, executor: Executor, properties: Properties) {
+  val log = LoggerFactory.getLogger(classOf[Producer])
+
+  private val producer = eurybates.Producer(sourceId, properties)
+  private val serviceConfiguration = new ServiceConfiguration(zkp, executor, setServiceNames)
+
+  def start(): Unit = {
+    producer.start()
+    serviceConfiguration.start()
+  }
+
+  def setServiceNames(serviceNames: Set[ServiceName]): Unit = {
+    producer.setServiceNames(serviceNames)
+  }
+
+  def shutdown(): Unit = {
+    producer.stop()
+  }
+
+  def send(message: String => ProducerMessage): Unit = {
+    val m = message(instance)
+    try {
+      producer.send(eurybates.Message(ProducerMessage.tag(m), JsonEncode.toJValue(m)))
+    } catch {
+      case e: IllegalStateException =>
+        log.error("Failed to send message! Are there no open sessions to queues?", e)
+    }
+  }
+}
+
+class ProducerConfig(config: Config, root: String) extends ConfigClass(config, root) {
+  def p(path: String) = root + "." + path
+  val eurybates = new EurybatesConfig(config, p("eurybates"))
+  val zookeeper = new ZookeeperConfig(config, p("zookeeper"))
+}
+
+class EurybatesConfig(config: Config, root: String) extends ConfigClass(config, root) {
+  val producers = getString("producers")
+  val activemqConnStr = getRawConfig("activemq").getString("connection-string")
+}
+
+class ZookeeperConfig(config: Config, root: String) extends ConfigClass(config, root) {
+  val connSpec = getString("conn-spec")
+  val sessionTimeout = getDuration("session-timeout").toMillis.toInt
+}
+
+object ProducerFromConfig {
+  def apply(watcherId: UUID, instance: String, executor: Executor, config: ProducerConfig): Producer = {
+    val properties = new Properties()
+    properties.setProperty("eurybates.producers", config.eurybates.producers)
+    properties.setProperty("eurybates.activemq.connection_string", config.eurybates.activemqConnStr)
+    val zkp = new ZooKeeperProvider(config.zookeeper.connSpec, config.zookeeper.sessionTimeout, executor)
+    new Producer(watcherId.toString, instance, zkp, executor, properties)
+  }
+}

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/ProducerMessage.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/ProducerMessage.scala
@@ -1,0 +1,57 @@
+package com.socrata.datacoordinator.secondary
+
+import com.rojoma.json.v3.util._
+import com.socrata.datacoordinator.id.DatasetId
+import com.socrata.eurybates.Tag
+
+sealed abstract class ProducerMessage
+
+@JsonKeyStrategy(Strategy.Underscore)
+case class StoreVersion(datasetSystemId: String,
+                        groupName: Option[String],
+                        storeId: String,
+                        newDataVersion: Long,
+                        startingAtMs: Long,
+                        endingAtMs: Long) extends ProducerMessage
+
+object StoreVersion {
+  implicit val encode = AutomaticJsonEncodeBuilder[StoreVersion]
+
+  def apply(datasetSystemId: DatasetId, groupName: Option[String], storeId: String,newDataVersion: Long,
+            startingAtMs: Long, endingAtMs: Long): String => StoreVersion = { instance =>
+    StoreVersion(WithInstance(instance, datasetSystemId), groupName, storeId, newDataVersion, startingAtMs, endingAtMs)
+  }
+}
+
+@JsonKeyStrategy(Strategy.Underscore)
+case class GroupVersion(datasetSystemId: String,
+                        groupName: String,
+                        storeIds: Set[String],
+                        newDataVersion: Long,
+                        endingAtMs: Long) extends ProducerMessage
+
+object GroupVersion {
+  implicit val encode = AutomaticJsonEncodeBuilder[GroupVersion]
+
+  def apply(datasetSystemId: DatasetId, groupName: String, storeIds: Set[String], newDataVersion: Long,
+            endingAtMs: Long): String => GroupVersion = { instance =>
+    GroupVersion(WithInstance(instance, datasetSystemId), groupName, storeIds, newDataVersion, endingAtMs)
+
+  }
+}
+
+object ProducerMessage {
+  implicit val encode = SimpleHierarchyEncodeBuilder[ProducerMessage](NoTag)
+    .branch[StoreVersion]
+    .branch[GroupVersion]
+    .build
+
+  def tag(message: ProducerMessage): Tag = message match {
+    case m: StoreVersion => "SECONDARY_DATA_VERSION_UPDATED"
+    case m: GroupVersion => "SECONDARY_GROUP_DATA_VERSION_UPDATED"
+  }
+}
+
+object WithInstance {
+  def apply(instance: String, datasetSystemId: DatasetId): String =  s"$instance.${datasetSystemId.underlying}"
+}

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
@@ -21,5 +21,5 @@ class SecondaryWatcherConfig(config: Config, root: String) {
   val maxReplayWait = config.getDuration(k("max-replay-wait"), MILLISECONDS).longValue.millis
   val replayWait = config.getDuration(k("replay-wait"), MILLISECONDS).longValue.millis
   val tmpdir = new java.io.File(config.getString(k("tmpdir"))).getAbsoluteFile
-  val producerConfig = new ProducerConfig(config, k("producer"))
+  val producerConfig = try { Some(new ProducerConfig(config, k("producer"))) } catch { case _: ConfigException.Missing => None }
 }

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
@@ -21,4 +21,5 @@ class SecondaryWatcherConfig(config: Config, root: String) {
   val maxReplayWait = config.getDuration(k("max-replay-wait"), MILLISECONDS).longValue.millis
   val replayWait = config.getDuration(k("replay-wait"), MILLISECONDS).longValue.millis
   val tmpdir = new java.io.File(config.getString(k("tmpdir"))).getAbsoluteFile
+  val producerConfig = new ProducerConfig(config, k("producer"))
 }

--- a/secondarylib/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
+++ b/secondarylib/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
@@ -51,9 +51,9 @@ class SecondaryWatcherTest extends FunSuite with MustMatchers with MockFactory {
     val testManifest = mock[SecondaryManifest]
 
     val w = new SecondaryWatcher(common.universe, watcherId, claimTimeout,
-                                 10.seconds, 60.seconds, 10.minutes, 2, 10, common.timingReport) {
+                                 10.seconds, 60.seconds, 10.minutes, 2, 10, common.timingReport, NoOpProducer) {
       override protected def manifest(u: Universe[common.CT, common.CV] with
-                                         SecondaryManifestProvider with PlaybackToSecondaryProvider):
+                                         SecondaryManifestProvider with PlaybackToSecondaryProvider with SecondaryStoresConfigProvider):
         SecondaryManifest = testManifest
     }
 
@@ -82,9 +82,9 @@ class SecondaryWatcherTest extends FunSuite with MustMatchers with MockFactory {
     val testManifest = mock[SecondaryManifest]
 
     val w = new SecondaryWatcher(common.universe, watcherId, claimTimeout,
-                                 10.seconds, 60.seconds, 10.minutes, 2, 10, common.timingReport) {
+                                 10.seconds, 60.seconds, 10.minutes, 2, 10, common.timingReport, NoOpProducer) {
       override protected def manifest(u: Universe[common.CT, common.CV] with
-                                         SecondaryManifestProvider with PlaybackToSecondaryProvider):
+                                         SecondaryManifestProvider with PlaybackToSecondaryProvider with SecondaryStoresConfigProvider):
         SecondaryManifest = testManifest
     }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.0-hack-week"
+version in ThisBuild := "3.2.1-hack-week-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.1-hack-week"
+version in ThisBuild := "3.2.2-hack-week-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.2.1-hack-week-SNAPSHOT"
+version in ThisBuild := "3.2.1-hack-week"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.1.7-SNAPSHOT"
+version in ThisBuild := "3.2.0-hack-week"


### PR DESCRIPTION
Enable secondary-watcher to send messages
to Eurybates when it completes a new
data-version for a given secondary store.