### PR TITLE
Rollup drop can generate table names with “-“ (version -1) 0 - 1 in s…

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/SqlLogTableCleanup.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/SqlLogTableCleanup.scala
@@ -52,7 +52,7 @@ class SqlLogTableCleanup(conn: Connection, deleteOlderThan: FiniteDuration, dele
             deletableVersion.foreach {
               version =>
                 val rowsDeleted = stmt.executeUpdate( s"""
-                  |DELETE FROM ${logTableName}
+                  |DELETE FROM "${logTableName}"
                   |WHERE version <= ${version}
                   """.stripMargin)
                 log.info(s"Removed ${rowsDeleted} rows up to version ${version} from ${logTableName}")

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/SqlTableCleanup.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/SqlTableCleanup.scala
@@ -16,7 +16,7 @@ class SqlTableCleanup(conn: Connection, daysDelay: Int = 1) extends TableCleanup
           val id = rs.getLong("id")
           val tableName = rs.getString("table_name")
           log.info("Physically dropping table " + tableName)
-          stmt.execute("DROP TABLE IF EXISTS " + tableName)
+          stmt.execute("DROP TABLE IF EXISTS \"" + tableName + "\"")
           using(conn.prepareStatement("DELETE FROM pending_table_drops WHERE id = ?")) { delStmt =>
             delStmt.setLong(1, id)
             delStmt.execute()


### PR DESCRIPTION
…ome tests.