### PR TITLE
EN-12729: Avoid deadlocks on `secondary_manifest`

### DIFF
--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml
@@ -17,12 +17,21 @@
               BEGIN
                 UPDATE secondary_manifest
                   SET went_out_of_sync_at = CURRENT_TIMESTAMP
-                  WHERE dataset_system_id = NEW.dataset_system_id AND latest_data_version = latest_secondary_data_version;
+                  WHERE (secondary_manifest.dataset_system_id, store_id) IN (
+                    SELECT dataset_system_id, store_id FROM secondary_manifest
+                    WHERE secondary_manifest.dataset_system_id = NEW.dataset_system_id
+                    ORDER BY store_id FOR UPDATE
+                  )
+                  AND latest_data_version = latest_secondary_data_version;
                 UPDATE secondary_manifest
                   SET latest_data_version = (
                     SELECT MAX(copy_map.data_version) FROM copy_map WHERE copy_map.dataset_system_id = NEW.dataset_system_id
                   )
-                  WHERE secondary_manifest.dataset_system_id = NEW.dataset_system_id;
+                  WHERE (secondary_manifest.dataset_system_id, store_id) IN (
+                    SELECT dataset_system_id, store_id FROM secondary_manifest
+                    WHERE secondary_manifest.dataset_system_id = NEW.dataset_system_id
+                    ORDER BY store_id FOR UPDATE
+                  );
 
                 -- and finally dataset_map
                 UPDATE dataset_map

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/SqlDatasetDropper.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/SqlDatasetDropper.scala
@@ -49,8 +49,8 @@ class SqlDatasetDropper[CT](conn: Connection, writeLockTimeout: Duration, datase
          |  SELECT dataset_system_id, store_id FROM secondary_manifest
          |  WHERE dataset_system_id = ? ORDER BY store_id FOR UPDATE
          |)""".stripMargin)) { stmt =>
-      stmt.setObject(1, fakeVersion)
-      stmt.setObject(2, datasetId.underlying)
+      stmt.setLong(1, fakeVersion)
+      stmt.setLong(2, datasetId.underlying)
       stmt.executeUpdate()
     }
   }


### PR DESCRIPTION
When updating multiple rows on the`secondary_manifest`
in `truth` first obtain locks on the rows in a
deterministic order to avoid deadlocks.

For this: order by `dataset_system_id` then `store_id`.