### PR TITLE
EN-15144: Add column for dataset resource_name

### DIFF
--- a/bin/run_migrations.sh
+++ b/bin/run_migrations.sh
@@ -3,13 +3,9 @@ set -e
 
 # Run data coordinator migrations
 # run_migrations.sh [migrate/undo/redo] [numchanges]
-REALPATH=$(python -c "import os; print(os.path.realpath('$0'))")
-BINDIR=$(dirname "$REALPATH")
-
 CONFIG="${SODA_CONFIG:-/etc/soda2.conf}" # TODO: Don't depend on soda2.conf.
-JARFILE=$("$BINDIR"/build.sh "$@")
 
 COMMAND=${1:-migrate}
 echo Running datacoordinator.primary.MigrateSchema "$COMMAND" "$2"...
 ARGS=( $COMMAND $2 )
-java -Djava.net.preferIPv4Stack=true -Dconfig.file="$CONFIG" -jar "$JARFILE" com.socrata.datacoordinator.primary.MigrateSchema "${ARGS[@]}"
+sbt -Dconfig.file="$CONFIG" "coordinator/run-main com.socrata.datacoordinator.primary.MigrateSchema ${ARGS[@]}"

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20170330-add-column-resource-name.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20170330-add-column-resource-name.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="Alexa Rust" id="20161006-add-column-resource-name">
+        <preConditions onFail="MARK_RAN">
+            <not>
+                <columnExists tableName="dataset_map" columnName="resource_name"/>
+            </not>
+        </preConditions>
+        <addColumn tableName="dataset_map">
+            <column name="resource_name" type="VARCHAR(128)">
+                <constraints nullable="true"/>
+            </column>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -27,6 +27,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20161006-add-column-group-name.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20161014-add-secondary-manifest-queue-index.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20170125-add-resync-table.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20170330-add-column-resource-name.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>


### PR DESCRIPTION
We want to start storing dataset resource_name in truth
so the secondary-watcher can include the external dataset
ids in messages in AMQ reporting replication complete.

These replication messages are so we can wait to calculate
column stats after replication is complete.

Also, update migrations script to use sbt instead of first
assembling a new jar (because that is slow).