### PR TITLE
EN-15144: Optionally write/read resource_name

### DIFF
--- a/coordinatorlib/src/main/protobuf/LogData.proto
+++ b/coordinatorlib/src/main/protobuf/LogData.proto
@@ -12,6 +12,7 @@ message UnanchoredDatasetInfo {
   required int64 nextCounterValue = 2;
   required string localeName = 3;
   required bytes obfuscationKey = 4;
+  optional string resourceName = 5;
 }
 
 message UnanchoredCopyInfo {

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/DatasetInfo.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/DatasetInfo.scala
@@ -1,3 +1,6 @@
 package com.socrata.datacoordinator.secondary
 
-case class DatasetInfo(internalName: String, localeName: String, obfuscationKey: Array[Byte])
+case class DatasetInfo(internalName: String,
+                       localeName: String,
+                       obfuscationKey: Array[Byte],
+                       resourceName: Option[String])

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
@@ -121,7 +121,7 @@ class PlaybackToSecondary[CT, CV](u: PlaybackToSecondary.SuperUniverse[CT, CV],
   }
 
   def makeSecondaryDatasetInfo(dsInfo: metadata.DatasetInfoLike) =
-    DatasetInfo(datasetIdFormatter(dsInfo.systemId), dsInfo.localeName, dsInfo.obfuscationKey.clone())
+    DatasetInfo(datasetIdFormatter(dsInfo.systemId), dsInfo.localeName, dsInfo.obfuscationKey.clone(), dsInfo.resourceName)
 
   def makeSecondaryCopyInfo(copyInfo: metadata.CopyInfoLike) =
     CopyInfo(copyInfo.systemId,

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/DatabaseAccessors.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/DatabaseAccessors.scala
@@ -183,7 +183,7 @@ trait DatasetMutator[CT, CV] {
 
   type TrueMutationContext <: MutationContext
 
-  def createDataset(as: String)(localeName: String): Managed[TrueMutationContext]
+  def createDataset(as: String)(localeName: String, resourceName: Option[String]): Managed[TrueMutationContext]
 
   def openDataset(as: String)(datasetId: DatasetId, check: DatasetCopyContext[CT] => Unit): Managed[Option[TrueMutationContext]]
 
@@ -484,11 +484,11 @@ object DatasetMutator {
         })
     }
 
-    def createDataset(as: String)(localeName: String) = new SimpleArm[S] {
+    def createDataset(as: String)(localeName: String, resourceName: Option[String]) = new SimpleArm[S] {
       def flatMap[A](f: S => A): A =
         for { llCtx <- databaseMutator.openDatabase } yield {
           val m = llCtx.datasetMap
-          val firstVersion = m.create(localeName)
+          val firstVersion = m.create(localeName, resourceName)
           val logger = llCtx.logger(firstVersion.datasetInfo, as)
           val schemaLoader = llCtx.schemaLoader(logger)
           schemaLoader.create(firstVersion)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/messages/FromProtobuf.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/messages/FromProtobuf.scala
@@ -53,7 +53,8 @@ object FromProtobuf {
        systemId = new DatasetId(di.systemId),
        nextCounterValue = di.nextCounterValue,
        localeName = di.localeName,
-       obfuscationKey = di.obfuscationKey.toByteArray
+       obfuscationKey = di.obfuscationKey.toByteArray,
+       resourceName = di.resourceName
      )
 
   def convert(ri: UnanchoredRollupInfo): metadata.UnanchoredRollupInfo =

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetInfo.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetInfo.scala
@@ -11,6 +11,7 @@ trait DatasetInfoLike extends Product {
   val nextCounterValue: Long
   val localeName: String
   val obfuscationKey: Array[Byte]
+  val resourceName: Option[String]
 
   lazy val tableBase = "t" + systemId.underlying
   lazy val auditTableName = tableBase + "_audit"
@@ -20,9 +21,10 @@ trait DatasetInfoLike extends Product {
 case class UnanchoredDatasetInfo(@JsonKey("sid") systemId: DatasetId,
                                  @JsonKey("ctr") nextCounterValue: Long,
                                  @JsonKey("locale") localeName: String,
-                                 @JsonKey("obfkey") obfuscationKey: Array[Byte]) extends DatasetInfoLike
+                                 @JsonKey("obfkey") obfuscationKey: Array[Byte],
+                                 @JsonKey("resource") resourceName: Option[String]) extends DatasetInfoLike
 
-object UnanchoredDatasetInfo extends ((DatasetId, Long, String, Array[Byte]) => UnanchoredDatasetInfo) {
+object UnanchoredDatasetInfo extends ((DatasetId, Long, String, Array[Byte], Option[String]) => UnanchoredDatasetInfo) {
   override def toString = "DatasetInfo"
   private implicit val byteCodec = new JsonDecode[Array[Byte]] with JsonEncode[Array[Byte]] {
     def encode(x: Array[Byte]): JValue =
@@ -43,15 +45,16 @@ object UnanchoredDatasetInfo extends ((DatasetId, Long, String, Array[Byte]) => 
   * or [[com.socrata.datacoordinator.truth.metadata.DatasetMapWriter]].
   * @param tag Guard against a non-map accidentially instantiating this.
   */
-case class DatasetInfo(systemId: DatasetId, nextCounterValue: Long, localeName: String, obfuscationKey: Array[Byte])(implicit tag: com.socrata.datacoordinator.truth.metadata.`-impl`.Tag) extends DatasetInfoLike {
-  def unanchored: UnanchoredDatasetInfo = UnanchoredDatasetInfo(systemId, nextCounterValue, localeName, obfuscationKey)
+case class DatasetInfo(systemId: DatasetId, nextCounterValue: Long, localeName: String, obfuscationKey: Array[Byte], resourceName: Option[String])(implicit tag: com.socrata.datacoordinator.truth.metadata.`-impl`.Tag) extends DatasetInfoLike {
+  def unanchored: UnanchoredDatasetInfo = UnanchoredDatasetInfo(systemId, nextCounterValue, localeName, obfuscationKey, resourceName)
 
   override def equals(o: Any) = o match {
     case that: DatasetInfo =>
       this.systemId == that.systemId &&
         this.nextCounterValue == that.nextCounterValue &&
         this.localeName == that.localeName &&
-        java.util.Arrays.equals(this.obfuscationKey, that.obfuscationKey) // thanks, java
+        java.util.Arrays.equals(this.obfuscationKey, that.obfuscationKey) && // thanks, java
+        this.resourceName == that.resourceName
     case _ =>
       false
   }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
@@ -32,7 +32,7 @@ trait DatasetMapWriter[CT] extends DatasetMapBase[CT] with `-impl`.BaseDatasetMa
   /** Creates a new dataset in the truthstore.
     * @note Does not actually create any tables; this just updates the bookkeeping.
     * @return A `CopyInfo` that refers to an unpublished copy. */
-  def create(localeName: String): CopyInfo
+  def create(localeName: String, resourceName: Option[String]): CopyInfo
 
   /** Ensures that an "unpublished" table exists, creating it if necessary.
     * @note Does not copy the actual tables; this just updates the bookkeeping.
@@ -61,7 +61,7 @@ trait BackupDatasetMap[CT] extends DatasetMapWriter[CT] with `-impl`.BaseDataset
     * @note Does not actually create any tables; this just updates the bookkeeping.
     * @throws DatasetSystemIdAlreadyInUse if `systemId` is already in use.
     * @return A `CopyInfo` that refers to an unpublished copy with system id `systemId`. */
-  def createWithId(systemId: DatasetId, initialCopySystemId: CopyId, localeName: String, obfuscationKey: Array[Byte]): CopyInfo
+  def createWithId(systemId: DatasetId, initialCopySystemId: CopyId, localeName: String, obfuscationKey: Array[Byte], resourceName: Option[String]): CopyInfo
 
   /** Ensures that an "unpublished" table exists, creating it if necessary.
     * @note Does not copy the actual tables; this just updates the bookkeeping.
@@ -89,13 +89,15 @@ trait BackupDatasetMap[CT] extends DatasetMapWriter[CT] with `-impl`.BaseDataset
   def unsafeCreateDataset(systemId: DatasetId,
                           nextCounterValue: Long,
                           localeName: String,
-                          obfuscationKey: Array[Byte]): DatasetInfo
+                          obfuscationKey: Array[Byte],
+                          resourceName: Option[String]): DatasetInfo
 
   /** Creates a dataset with the specified attributes
     * @note Using this carelessly can get you into trouble.  In particular, this
     *       newly created dataset will have NO copies attached. */
   def unsafeCreateDatasetAllocatingSystemId(localeName: String,
-                                            obfuscationKey: Array[Byte]): DatasetInfo
+                                            obfuscationKey: Array[Byte],
+                                            resourceName: Option[String]): DatasetInfo
 
   /** Reloads a dataset with the specified attributes, including CLEARING ALL COPIES.
     * @note Using this carelessly can get you into trouble.  It is intended to be used
@@ -103,7 +105,8 @@ trait BackupDatasetMap[CT] extends DatasetMapWriter[CT] with `-impl`.BaseDataset
   def unsafeReloadDataset(datasetInfo: DatasetInfo,
                           nextCounterValue: Long,
                           localeName: String,
-                          obfuscationKey: Array[Byte]): DatasetInfo
+                          obfuscationKey: Array[Byte],
+                          resourceName: Option[String]): DatasetInfo
 
   /** Creates a copy with the specified attributes.
     * @note Using this carelessly can get you into trouble.  It is intended to be used


### PR DESCRIPTION
Add "resource" as an optional field to the dataset
creation "c" command in creation mutation scripts.
Read and write optional/nullable `resource_name`
from `dataset_map`.

Dataset `resource_name` will be used in Eurybates
messages for replication completion events sent
from secondary-watcher for waiting to compute NBE
column statistics.

Depends upon migration in:
990536323ace1fcb22288f97f9d17cba81025eec