### PR TITLE
EN-1281: add support for more JDBC timeout configs

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/DataSourceFromConfig.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/DataSourceFromConfig.scala
@@ -18,9 +18,9 @@ class DataSourceConfig(config: Config, root: String) extends ConfigClass(config,
   val password = getString("password")
   val applicationName = getString("app-name")
   val tcpKeepAlive = optionally(getBoolean("tcp-keep-alive")).getOrElse(false)
-  val loginTimeout = optionally(getInt("login-timeout"))
-  val connectTimeout = optionally(getInt("connect-timeout"))
-  val cancelSignalTimeout = optionally(getInt("cancel-signal-timeout"))
+  val loginTimeout = optionally(getDuration("login-timeout"))
+  val connectTimeout = optionally(getDuration("connect-timeout"))
+  val cancelSignalTimeout = optionally(getDuration("cancel-signal-timeout"))
   val poolOptions = optionally(getRawConfig("c3p0")) // these are the c3p0 configuration properties
 }
 
@@ -38,9 +38,9 @@ object DataSourceFromConfig {
         dataSource.setApplicationName(config.applicationName)
         dataSource.setTcpKeepAlive(config.tcpKeepAlive)
         // for these optional configs, we should fall back to the driver's default, if no value is specified
-        config.loginTimeout.foreach(t => dataSource.setLoginTimeout(t))
-        config.connectTimeout.foreach(t => dataSource.setConnectTimeout(t))
-        config.cancelSignalTimeout.foreach(t => dataSource.setCancelSignalTimeout(t))
+        config.loginTimeout.foreach(t => dataSource.setLoginTimeout(t.toSeconds.toInt))
+        config.connectTimeout.foreach(t => dataSource.setConnectTimeout(t.toSeconds.toInt))
+        config.cancelSignalTimeout.foreach(t => dataSource.setCancelSignalTimeout(t.toSeconds.toInt))
         config.poolOptions match {
           case Some(poolOptions) =>
             val overrideProps = C3P0Propertizer("", poolOptions)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/DataSourceFromConfig.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/DataSourceFromConfig.scala
@@ -18,6 +18,9 @@ class DataSourceConfig(config: Config, root: String) extends ConfigClass(config,
   val password = getString("password")
   val applicationName = getString("app-name")
   val tcpKeepAlive = optionally(getBoolean("tcp-keep-alive")).getOrElse(false)
+  val loginTimeout = optionally(getInt("login-timeout"))
+  val connectTimeout = optionally(getInt("connect-timeout"))
+  val cancelSignalTimeout = optionally(getInt("cancel-signal-timeout"))
   val poolOptions = optionally(getRawConfig("c3p0")) // these are the c3p0 configuration properties
 }
 
@@ -34,6 +37,10 @@ object DataSourceFromConfig {
         dataSource.setPassword(config.password)
         dataSource.setApplicationName(config.applicationName)
         dataSource.setTcpKeepAlive(config.tcpKeepAlive)
+        // for these optional configs, we should fall back to the driver's default, if no value is specified
+        config.loginTimeout.foreach(t => dataSource.setLoginTimeout(t))
+        config.connectTimeout.foreach(t => dataSource.setConnectTimeout(t))
+        config.cancelSignalTimeout.foreach(t => dataSource.setCancelSignalTimeout(t))
         config.poolOptions match {
           case Some(poolOptions) =>
             val overrideProps = C3P0Propertizer("", poolOptions)

--- a/project/CoordinatorLib.scala
+++ b/project/CoordinatorLib.scala
@@ -26,7 +26,7 @@ object CoordinatorLib {
       "org.iq80.snappy" % "snappy" % "0.3",
       "org.liquibase" % "liquibase-core" % "2.0.0",
       "org.liquibase" % "liquibase-plugin" % "1.9.5.0",
-      "org.postgresql" % "postgresql" % "9.3-1102-jdbc41", // we do use postgres-specific features some places
+      "org.postgresql" % "postgresql" % "9.4.1212", // we do use postgres-specific features some places
       "org.xerial.snappy" % "snappy-java" % "1.1.0-M3",
 
       TestDeps.scalaCheck % "test,it",


### PR DESCRIPTION
And strongly type them right into some classes.

A param we want to use cancelSignalTimeout requires 9.4.1209 or higher:
https://jdbc.postgresql.org/documentation/94/connect.html