### PR TITLE
Explicitly pin Scala version.

### DIFF
--- a/project/BuildSettings.scala
+++ b/project/BuildSettings.scala
@@ -25,6 +25,7 @@ object BuildSettings {
         testOptions in ExploratoryTest <<= testOptions in Test,
         testOptions in UnitTest <<= (testOptions in Test) map { _ ++ Seq(Tests.Argument("-l", "Slow")) },
         scalacOptions += "-language:implicitConversions",
+        scalaVersion := "2.10.6",
         libraryDependencies ++=
           Seq(
             slf4jApi


### PR DESCRIPTION
This is a good thing to do anyway, but the specific reason for doing
it is it looks like different versions are fighting resulting in
strange "java.lang.ClassNotFoundException: scala.Some" errors.

I briefly looked at upgrading past 2.10, but we are still blocked by the
sbt-scalabuff plugin, which we would need to either fork and update or
replace.