### PR TITLE
EN-16084 Minimimal change to bump soql-ref version.

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/DatabaseAccessors.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/DatabaseAccessors.scala
@@ -4,7 +4,7 @@ package truth
 import com.rojoma.json.v3.ast.{JNumber, JString, JValue}
 import com.rojoma.json.v3.codec.JsonEncode
 import com.socrata.datacoordinator.util.CopyContextResult
-import com.socrata.soql.environment.ColumnName
+import com.socrata.soql.environment.{ColumnName, TableName}
 import org.joda.time.DateTime
 import com.rojoma.simplearm.{Managed, SimpleArm}
 import com.socrata.datacoordinator.truth.metadata._
@@ -396,7 +396,7 @@ object DatasetMutator {
           val analyzer = soqlAnalyzer
           rollups.foreach { (ru: RollupInfo) =>
             try {
-              analyzer.analyzeFullQuery(ru.soql)(prefixedDsContext)
+              analyzer.analyzeFullQuery(ru.soql)(Map(TableName.PrimaryTable.qualifier -> prefixedDsContext))
             } catch {
               case ex: NoSuchColumn =>
                 log.info(s"drop rollup ${ru.name.underlying} because ${ex.getMessage}")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     val scalaCheck      = "1.11.0"
     val scalaMock       = "3.2"
     val slf4j           = "1.7.5"
-    val soqlReference   = "2.0.11"
+    val soqlReference   = "2.2.0"
     val thirdPartyUtils = "4.0.1"
     val curatorUtils    = "1.0.3"
     val typesafeConfig  = "1.2.1"


### PR DESCRIPTION
We want to do this now so that we will not be blocked if there is an urgent need to bump soil-ref for non join related work.