### PR TITLE
EN-16800 setChangeLogLockWaitTime to a value smaller (3s) than sql lo…

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/migration/Migration.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/migration/Migration.scala
@@ -1,13 +1,10 @@
 package com.socrata.datacoordinator.truth.migration
 
 import liquibase.Liquibase
-import liquibase.database.jvm.JdbcConnection
-import liquibase.logging.LogFactory
+import liquibase.lockservice.LockService
 import liquibase.resource.ClassLoaderResourceAccessor
-
 import java.sql.Connection
 
-import scala.Enumeration
 
 /**
  * Interface with the Liquibase library to perform schema migrations on a given database with a given set of changes.
@@ -29,6 +26,8 @@ object Migration {
                 changeLogPath: String = MigrationScriptPath) {
     val jdbc = new NonCommmittingJdbcConnenction(conn)
     val liquibase = new Liquibase(changeLogPath, new ClassLoaderResourceAccessor, jdbc)
+    val lockService = LockService.getInstance(liquibase.getDatabase)
+    lockService.setChangeLogLockWaitTime(1000 * 3) // 3s where value should be < SQL lock_timeout (30s)
     val database = conn.getCatalog
 
     operation match {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
     val scalaCheck      = "1.11.0"
     val scalaMock       = "3.2"
     val slf4j           = "1.7.5"
-    val soqlReference   = "2.2.1"
+    val soqlReference   = "2.2.5"
     val thirdPartyUtils = "4.0.1"
     val curatorUtils    = "1.0.3"
     val typesafeConfig  = "1.2.1"


### PR DESCRIPTION
…ck_timeout (30s) so that migrations where runInTransaction="false" should go through fine.

Also bump soql-refernce just to get the latest version which should not change anything.