### PR TITLE
EN-18249: Migrate geocoding secondary cookie

### DIFF
--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20170915-migrate-geocoding-secondary-cookie.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20170915-migrate-geocoding-secondary-cookie.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="Alexa Rust" id="20170915-migrate-geocoding-secondary-cookie">
+        <sql>
+            UPDATE secondary_manifest
+               SET cookie = replace(replace(cookie,
+                                            '"computationRetriesLeft":0',
+                                            '"computationRetriesLeft":5'),
+                                    '"dataCoordinatorRetriesLeft":0',
+                                    '"dataCoordinatorRetriesLeft":5')
+             WHERE store_id = 'geocoding';
+        </sql>
+        <rollback>
+            UPDATE secondary_manifest
+               SET cookie = replace(replace(cookie,
+                                            '"computationRetriesLeft":5',
+                                            '"computationRetriesLeft":0'),
+                                    '"dataCoordinatorRetriesLeft":5',
+                                    '"dataCoordinatorRetriesLeft":0')
+             WHERE store_id = 'geocoding';
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -29,6 +29,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20170125-add-resync-table.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20170330-add-column-resource-name.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20170615-add-dataset-map-resource-name-index.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20170915-migrate-geocoding-secondary-cookie.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>


### PR DESCRIPTION
Migrate geocoding secondary cookie to reflect changes to cookie
logic from commit 2183e78064db3b916af01e6a1321cb2064d0d3ec in
FeedbackSecondary library. This should be run _before_ using the
new version 0.0.17 of secondary-watcher-geocoding and should be
safe to run at anytime prior.