### PR TITLE
EN-18250: Hack secondaries-of-dataset endpoint

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
@@ -122,12 +122,20 @@ class Main(common: SoQLCommon, serviceConfig: ServiceConfig) {
           }
         }
 
+        var hackedSecondaries = secondaries
+        if (feedbackSecondaries.nonEmpty) {
+          // the max version we want to return is the version that the feedback secondary has
+          // this is a hack for now, see EN-18250 for details
+          val maxVersion = secondaries.filterKeys(feedbackSecondaries.contains).values.min
+          hackedSecondaries = secondaries.mapValues(scala.math.min(maxVersion, _))
+        }
+
         SecondariesOfDatasetResult(
           latestVersion,
           latestVersion,
           publishedVersion,
           unpublishedVersion,
-          secondaries,
+          hackedSecondaries,
           feedbackSecondaries,
           groups.toMap
         )


### PR DESCRIPTION
Hack secondaries-of-dataset endpoint to return the min
of the feedback secondary version and the actual version
of a store for all stores.

This is so the views/4x4/replication.json endpoint can return
false for read replication being up to date if feedback
replication is still behind. This is to avoid customers potentially
running into problems if they have scripts checking the read up to
date value as we migrate all existing region coded datasets to
use the geocoding-secondary.