### PR TITLE
EN-18250: Hack secondaries-of-dataset endpoint (#186)

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.3.20-SNAPSHOT"
+version in ThisBuild := "3.3.20-EN-18250-HOTFIX"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "3.3.20-EN-18250-HOTFIX"
+version in ThisBuild := "3.3.21-SNAPSHOT"


### PR DESCRIPTION
Hack secondaries-of-dataset endpoint to return the min
of the feedback secondary version and the actual version
of a store for all stores.

This is so the views/4x4/replication.json endpoint can return
false for read replication being up to date if feedback
replication is still behind. This is to avoid customers potentially
running into problems if they have scripts checking the read up to
date value as we migrate all existing region coded datasets to
use the geocoding-secondary.