### PR TITLE
EN-19241: Add by_system_id option to row_data cmd

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
@@ -209,12 +209,12 @@ class Service(serviceConfig: ServiceConfig,
                 "commandIndex" -> JNumber(em.index),
                 "dataset" -> JString(formatDatasetId(datasetName)),
                 "value" -> id)
-            case Mutator.UpsertError(datasetName, NoSuchRowToUpdate(id), _) =>
+            case Mutator.UpsertError(datasetName, NoSuchRowToUpdate(id, _), _) =>
               datasetBadRequest(RowUpdateError.NO_SUCH_ID,
                 "commandIndex" -> JNumber(em.index),
                 "dataset" -> JString(formatDatasetId(datasetName)),
                 "value" -> id)
-            case Mutator.UpsertError(datasetName, VersionMismatch(id, expected, actual), rowVersionToJson) =>
+            case Mutator.UpsertError(datasetName, VersionMismatch(id, expected, actual, _), rowVersionToJson) =>
               datasetBadRequest(UpdateError.ROW_VERSION_MISMATCH,
                 "commandIndex" -> JNumber(em.index),
                 "dataset" -> JString(formatDatasetId(datasetName)),
@@ -225,7 +225,7 @@ class Service(serviceConfig: ServiceConfig,
               datasetBadRequest(UpdateError.VERSION_ON_NEW_ROW,
                 "commandIndex" -> JNumber(em.index),
                 "dataset" -> JString(formatDatasetId(datasetName)))
-            case Mutator.UpsertError(datasetName, InsertInUpdateOnly(id), _) =>
+            case Mutator.UpsertError(datasetName, InsertInUpdateOnly(id, _), _) =>
               datasetBadRequest(UpdateError.INSERT_IN_UPDATE_ONLY,
                 "commandIndex" -> JNumber(em.index),
                 "dataset" -> JString(formatDatasetId(datasetName)),

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/Sqlizer.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/Sqlizer.scala
@@ -6,7 +6,7 @@ import java.sql.{Connection, PreparedStatement}
 
 import com.socrata.datacoordinator.util.CloseableIterator
 import com.socrata.datacoordinator.truth.{DatasetContext, TypeContext}
-import com.socrata.datacoordinator.id.{RowVersion, RowId}
+import com.socrata.datacoordinator.id.{ColumnId, RowVersion, RowId}
 
 trait ReadDataSqlizer[CT, CV] {
   def datasetContext: DatasetContext[CT, CV]
@@ -14,11 +14,8 @@ trait ReadDataSqlizer[CT, CV] {
 
   def dataTableName: String
 
-  // convenience method; like calling findRowsSubset with all column IDs in the
-  // dataset.
-  def findRows(conn: Connection, ids: Iterator[CV]): CloseableIterator[Seq[InspectedRow[CV]]]
-  // Not sure this will survive the row version feature
-  def findIdsAndVersions(conn: Connection, ids: Iterator[CV]): CloseableIterator[Seq[InspectedRowless[CV]]]
+  // convenience method; like calling findRowsSubset with all column IDs in the dataset.
+  def findRows(conn: Connection, bySystemId: Boolean, ids: Iterator[CV]): CloseableIterator[Seq[InspectedRow[CV]]]
 }
 
 /** Generates SQL for execution. */
@@ -29,7 +26,7 @@ trait DataSqlizer[CT, CV] extends ReadDataSqlizer[CT, CV] {
   def updateStatistics(conn: Connection, rowsAdded: Long, rowsDeleted: Long, rowsChanged: Long, preload: PreloadStatistics): PreloadStatistics
 
   def softMaxBatchSize: Int
-  def sizeofDelete(id: CV): Int
+  def sizeofDelete(id: CV, bySystemIdForced: Boolean): Int
   def sizeof(row: Row[CV]): Int
 
   def insertBatch[T](conn: Connection)(t: Inserter => T): (Long, T)

--- a/coordinatorlib/src/test/scala/com/socrata/datacoordinator/truth/loader/sql/StupidSqlLoader.scala
+++ b/coordinatorlib/src/test/scala/com/socrata/datacoordinator/truth/loader/sql/StupidSqlLoader.scala
@@ -1,14 +1,29 @@
-package com.socrata.datacoordinator
-package truth.loader
-package sql
+package com.socrata.datacoordinator.truth.loader.sql
 
 import java.sql.Connection
 
 import com.rojoma.simplearm.util._
-
-import com.socrata.datacoordinator.util.{RowIdProvider, RowVersionProvider}
+import com.socrata.datacoordinator._
 import com.socrata.datacoordinator.id.RowVersion
+import com.socrata.datacoordinator.truth.loader._
+import com.socrata.datacoordinator.util.{RowIdProvider, RowVersionProvider}
 
+/**
+ * For use in testing the real implementation, SqlLoader, of trait Loader
+ *
+ *    _____________________________________
+ *   / StupidSqlLoader should generate the \
+ *   | same results as SqlLoader           |
+ *   |                                     |
+ *   | ... just in a more straightforward  |
+ *   \ (stupid) fashion                    /
+ *   -------------------------------------
+ *          \   ^__^
+ *           \  (oo)\_______
+ *              (__)\       )\/\
+ *                  ||----w |
+ *                  ||     ||
+ */
 class StupidSqlLoader[CT, CV](val connection: Connection,
                               val rowPreparer: RowPreparer[CV],
                               val updateOnly: Boolean,
@@ -36,13 +51,40 @@ class StupidSqlLoader[CT, CV](val connection: Connection,
       case None => None
     }
 
-  def upsert(job: Int, unpreparedRow: Row[CV]) {
+  def upsert(job: Int, unpreparedRow: Row[CV], bySystemId: Boolean) {
+    def updateRowBySystemId(id: CV, updateForcedBySystemId: Boolean): Unit = {
+      using(connection.createStatement()) { _ =>
+        findRow(id, bySystemIdForced = updateForcedBySystemId) match {
+          case Some(InspectedRow(_, sid, oldVersion, oldRow)) =>
+            def doUpdate() {
+              val newVersion = versionProvider.allocate()
+              val updateRow = rowPreparer.prepareForUpdate(unpreparedRow, oldRow = oldRow, newVersion = newVersion)
+              using(connection.prepareStatement(sqlizer.prepareSystemIdUpdateStatement)) { stmt =>
+                sqlizer.prepareSystemIdUpdate(stmt, sid, updateRow)
+                val result = stmt.executeUpdate()
+                assert(result == 1, "From update: " + result)
+              }
+              dataLogger.update(sid, Some(oldRow), updateRow)
+              reportWriter.updated(job, IdAndVersion(id, newVersion, bySystemIdForced = updateForcedBySystemId))
+            }
+            versionOf(unpreparedRow) match {
+              case None => doUpdate()
+              case Some(Some(v)) if v == oldVersion => doUpdate()
+              case Some(other) => reportWriter.error(job, VersionMismatch(id, None, other, bySystemIdForced = updateForcedBySystemId))
+            }
+          case None =>
+            reportWriter.error(job, NoSuchRowToUpdate(id, bySystemIdForced = updateForcedBySystemId))
+        }
+      }
+    }
+
     checkJob(job)
     datasetContext.userPrimaryKeyColumn match {
       case Some(pkCol) =>
+        // if there is a user primary key column, first attempt to find the user primary key value
         unpreparedRow.get(pkCol) match {
           case Some(id) =>
-            findRow(id) match {
+            findRow(id, bySystemIdForced = false) match {
               case Some(InspectedRow(_, sid, oldVersion, oldRow)) =>
                 def doUpdate() {
                   val newVersion = versionProvider.allocate()
@@ -53,12 +95,12 @@ class StupidSqlLoader[CT, CV](val connection: Connection,
                   }
                   assert(updatedCount == 1)
                   dataLogger.update(sid, Some(oldRow), updateRow)
-                  reportWriter.updated(job, IdAndVersion(id, newVersion))
+                  reportWriter.updated(job, IdAndVersion(id, newVersion, bySystemIdForced = false))
                 }
                 versionOf(unpreparedRow) match {
                   case None => doUpdate()
                   case Some(Some(v)) if v == oldVersion => doUpdate()
-                  case Some(other) => reportWriter.error(job, VersionMismatch(id, Some(oldVersion), other))
+                  case Some(other) => reportWriter.error(job, VersionMismatch(id, Some(oldVersion), other, bySystemIdForced = false))
                 }
               case None =>
                 versionOf(unpreparedRow) match {
@@ -71,54 +113,38 @@ class StupidSqlLoader[CT, CV](val connection: Connection,
                     }
                     assert(result == 1, "From insert: " + result)
                     dataLogger.insert(sid, insertRow)
-                    reportWriter.inserted(job, IdAndVersion(id, version))
+                    reportWriter.inserted(job, IdAndVersion(id, version, bySystemIdForced = false))
                   case Some(other) =>
-                    reportWriter.error(job, VersionMismatch(id, None, other))
+                    reportWriter.error(job, VersionMismatch(id, None, other, bySystemIdForced = false))
                 }
             }
-          case None =>
-            reportWriter.error(job, NoPrimaryKey)
+          case None if bySystemId =>
+            // here we will update a row with the system id instead of the user primary key if the system id was given
+            unpreparedRow.get(datasetContext.systemIdColumn) match {
+              case Some(id) => updateRowBySystemId(id, updateForcedBySystemId = true)
+              case None => reportWriter.error(job, NoPrimaryKey)
+            }
+          case None => reportWriter.error(job, NoPrimaryKey)
         }
       case None =>
+        // "by_system_id" is considered false here since there is no user primary key column
         unpreparedRow.get(datasetContext.systemIdColumn) match {
           case Some(id) =>
-            using(connection.createStatement()) { stmt =>
-              findRow(id) match {
-                case Some(InspectedRow(_, sid, oldVersion, oldRow)) =>
-                  def doUpdate() {
-                    val newVersion = versionProvider.allocate()
-                    val updateRow = rowPreparer.prepareForUpdate(unpreparedRow, oldRow = oldRow, newVersion = newVersion)
-                    using(connection.prepareStatement(sqlizer.prepareSystemIdUpdateStatement)) { stmt =>
-                      sqlizer.prepareSystemIdUpdate(stmt, sid, updateRow)
-                      val result = stmt.executeUpdate()
-                      assert(result == 1, "From update: " + result)
-                    }
-                    dataLogger.update(sid, Some(oldRow), updateRow)
-                    reportWriter.updated(job, IdAndVersion(id, newVersion))
-                  }
-                  versionOf(unpreparedRow) match {
-                    case None => doUpdate()
-                    case Some(Some(v)) if v == oldVersion => doUpdate()
-                    case Some(other) => reportWriter.error(job, VersionMismatch(id, None, other))
-                  }
-                case None =>
-                  reportWriter.error(job, NoSuchRowToUpdate(id))
-              }
-            }
+            updateRowBySystemId(id, updateForcedBySystemId = false)
           case None =>
             versionOf(unpreparedRow) match {
               case None | Some(None) =>
                 val sid = idProvider.allocate()
                 val version = versionProvider.allocate()
                 val insertRow = rowPreparer.prepareForInsert(unpreparedRow, sid, version)
-                if(updateOnly) reportWriter.error(job, InsertInUpdateOnly(insertRow(datasetContext.systemIdColumn)))
+                if(updateOnly) reportWriter.error(job, InsertInUpdateOnly(insertRow(datasetContext.systemIdColumn), bySystemIdForced = false))
                 else {
                   val (result, ()) = sqlizer.insertBatch(connection) { inserter =>
                     inserter.insert(insertRow)
                   }
                   assert(result == 1, "From insert: " + result)
                   dataLogger.insert(sid, insertRow)
-                  reportWriter.inserted(job, IdAndVersion(insertRow(datasetContext.systemIdColumn), typeContext.makeRowVersionFromValue(insertRow(datasetContext.versionColumn))))
+                  reportWriter.inserted(job, IdAndVersion(insertRow(datasetContext.systemIdColumn), typeContext.makeRowVersionFromValue(insertRow(datasetContext.versionColumn)), bySystemIdForced = false))
                 }
               case Some(Some(_)) =>
                 reportWriter.error(job, VersionOnNewRow)
@@ -127,25 +153,18 @@ class StupidSqlLoader[CT, CV](val connection: Connection,
     }
   }
 
-  def findRow(id: CV): Option[InspectedRow[CV]] = {
-    using(sqlizer.findRows(connection, Iterator.single(id))) { blocks =>
+  def findRow(id: CV, bySystemIdForced: Boolean): Option[InspectedRow[CV]] = {
+    using(sqlizer.findRows(connection, bySystemIdForced, Iterator.single(id))) { blocks =>
       val sids = blocks.flatten.toSeq
       assert(sids.length < 2)
       sids.headOption
     }
   }
 
-  def findRowId(id: CV): Option[InspectedRowless[CV]] = {
-    using(sqlizer.findIdsAndVersions(connection, Iterator.single(id))) { blocks =>
-      val sids = blocks.flatten.toSeq
-      assert(sids.length < 2)
-      sids.headOption
-    }
-  }
-
-  def delete(job: Int, id: CV, version: Option[Option[RowVersion]]) {
+  def delete(job: Int, id: CV, version: Option[Option[RowVersion]], bySystemId: Boolean) {
     checkJob(job)
-    findRow(id) match {
+    val deleteForcedBySystemId = datasetContext.hasUserPrimaryKey && bySystemId
+    findRow(id, deleteForcedBySystemId) match {
       case Some(InspectedRow(_, sid, oldVersion, oldRow)) =>
         def doDelete() {
           val (result, ()) = sqlizer.deleteBatch(connection) { deleter =>
@@ -158,7 +177,7 @@ class StupidSqlLoader[CT, CV](val connection: Connection,
         version match {
           case None => doDelete()
           case Some(Some(v)) if v == oldVersion => doDelete()
-          case Some(other) => reportWriter.error(job, VersionMismatch(id, Some(oldVersion), other))
+          case Some(other) => reportWriter.error(job, VersionMismatch(id, Some(oldVersion), other, bySystemIdForced = deleteForcedBySystemId))
         }
       case None =>
         reportWriter.error(job, NoSuchRowToDelete(id))

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackCookie.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackCookie.scala
@@ -38,6 +38,9 @@ object FeedbackCookie {
     Some(CompactJsonWriter.toString(feedbackCookieCodec.encode(fbc)))
   }
 
+  def encodeOnError(reason: String, fbc: Option[FeedbackCookie]): Cookie =
+    fbc.map(encode).getOrElse(Some(s"{errorMessage:$reason}"))
+
   def decode(ck: Cookie): Option[FeedbackCookie] = try {
     ck.flatMap(JsonUtil.parseJson[FeedbackCookie](_).right.toOption) // safely handle cookie corruption
   } catch {
@@ -48,7 +51,7 @@ object FeedbackCookie {
 
 case class CookieSchema(dataVersion: DataVersion,
                         copyNumber: CopyNumber,
-                        primaryKey: UserColumnId,
+                        systemId: UserColumnId,
                         columnIdMap: Map[UserColumnId, ColumnId],
                         strategyMap: Map[UserColumnId, ComputationStrategyInfo],
                         obfuscationKey: Array[Byte],
@@ -61,7 +64,7 @@ case class CookieSchema(dataVersion: DataVersion,
       case other: CookieSchema =>
         this.dataVersion == other.dataVersion &&
           this.copyNumber == other.copyNumber &&
-          this.primaryKey == other.primaryKey &&
+          this.systemId == other.systemId &&
           this.columnIdMap == other.columnIdMap &&
           this.strategyMap == other.strategyMap &&
           java.util.Arrays.equals(this.obfuscationKey, other.obfuscationKey) && // stupid arrays
@@ -76,7 +79,7 @@ case class CookieSchema(dataVersion: DataVersion,
     var code = 17
     code = code * 41 + (if (dataVersion == null) 0 else dataVersion.hashCode)
     code = code * 41 + (if (copyNumber == null) 0 else copyNumber.hashCode)
-    code = code * 41 + primaryKey.hashCode
+    code = code * 41 + systemId.hashCode
     code = code * 41 + (if (columnIdMap == null) 0 else columnIdMap.hashCode)
     code = code * 41 + (if (strategyMap == null) 0 else strategyMap.hashCode)
     code = code * 41 + java.util.Arrays.hashCode(obfuscationKey)

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/RequestFailure.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/RequestFailure.scala
@@ -28,16 +28,8 @@ sealed abstract class SchemaFailure {
 
 sealed abstract class UpdateSchemaFailure extends SchemaFailure
 
-case class PrimaryKeyColumnDoesNotExist(id: UserColumnId) extends UpdateSchemaFailure {
-  val english = s"Primary key column ${id.underlying} does not exist"
-}
-
 case class TargetColumnDoesNotExist(id: UserColumnId) extends UpdateSchemaFailure {
   val english = s"Target column ${id.underlying} does not exist"
-}
-
-case object PrimaryKeyColumnHasChanged extends UpdateSchemaFailure {
-  val english = "The primary key column has changed"
 }
 
 case class ColumnsDoNotExist(columns: Set[UserColumnId]) extends SchemaFailure {

--- a/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/CookieOperatorTest.scala
+++ b/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/CookieOperatorTest.scala
@@ -40,7 +40,7 @@ class CookieOperatorTest extends FunSuite with ShouldMatchers {
   val cookie = CookieSchema(
     dataVersion = DataVersion(100),
     copyNumber = CopyNumber(5),
-    primaryKey = new UserColumnId(":id"),
+    systemId = new UserColumnId(":id"),
     columnIdMap = columns,
     strategyMap = computedColumns,
     obfuscationKey = Array(),

--- a/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/TestData.scala
+++ b/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/TestData.scala
@@ -107,7 +107,7 @@ object TestData {
 
     val commands: Seq[JValue] =
       j"""[ { "c" : "normal", "user" : "addition-secondary" }
-        , { "c" : "row data", "update_only" : true, "nonfatal_row_errors" : [ "insert_in_update_only", "no_such_row_to_update" ] }
+        , { "c" : "row data", "update_only" : true, "by_system_id" : true, "nonfatal_row_errors" : [ "insert_in_update_only", "no_such_row_to_update" ] }
         ]""".toSeq
 
     val batchSize = 5
@@ -164,7 +164,7 @@ object TestData {
                              strategyMap: Map[UserColumnId, ComputationStrategyInfo] = Map.empty) =
       CookieSchema(dataVersion = DataVersion(version),
                    copyNumber = CopyNumber(number),
-                   primaryKey = systemPK.id,
+                   systemId = systemPK.id,
                    columnIdMap = columnIdMap,
                    strategyMap = strategyMap,
                    obfuscationKey = "magicmagic".getBytes,


### PR DESCRIPTION
Add by_system_id option to row_data command in the mutation script.

The option only changes the behavior of upserts and deletes for
datasets with user primary keys set in the following ways:

 - updates may be made to rows using the system id column.
 - if a user primary key column value and a system id colum
   value is given, the user primary key is prefered.
 - all deletes are assumed to be made using the system id column.

This option is to support the FeedbackSecondary library so that
a feedback secondary does not need to track the user primary key
column and not have to make guesses about if the primary key
column has changed based on errors from data-coordinator.

WIP: need to verify that the log_data has not been altered, and
fix the remaining failing unit test.