### PR TITLE
Periodically update stats, take two.

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/PostgresRepBasedDataSqlizer.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/PostgresRepBasedDataSqlizer.scala
@@ -55,26 +55,37 @@ class PostgresRepBasedDataSqlizer[CT, CV](tableName: String,
     }
   }
 
-  type PreloadStatistics = Long
+  case class StatSpec(pgCount: Long, added: Long, deleted: Long)
+  type PreloadStatistics = StatSpec
 
   def computeStatistics(conn: Connection): PreloadStatistics =
     using(conn.prepareStatement("SELECT reltuples FROM pg_class WHERE relname=?")) { stmt =>
       stmt.setString(1, tableName)
       using(stmt.executeQuery()) { rs =>
         if(rs.next()) {
-          rs.getLong("reltuples")
+          StatSpec(rs.getLong("reltuples"), 0, 0)
         } else {
-          0L
+          StatSpec(0, 0, 0)
         }
       }
     }
 
-  def updateStatistics(conn: Connection, rowsAdded: Long, rowsDeleted: Long, rowsChanged: Long, preload: PreloadStatistics) {
-    if(rowsAdded + rowsDeleted + rowsChanged >= preload / 10) {
+  def updateStatistics(conn: Connection, rowsAdded: Long, rowsDeleted: Long, rowsChanged: Long, preload: PreloadStatistics): PreloadStatistics = {
+    // If we have grown and/or shrunk the table by more than about 25%
+    // beyond what PG believed the row count to have been (with a
+    // minimum of 10000 rows to prevent a flurry of ANALYZEs during
+    // the initial growth phase), we should poke the PG statistics for
+    // it.
+    val totalAdded = preload.added + rowsAdded
+    val totalDeleted = preload.deleted + rowsDeleted
+    if(totalAdded + totalDeleted >= Math.max(10000, preload.pgCount / 4)) {
       val cols = (sidRep.physColumns ++ pkRep.physColumns).toSet
       using(conn.prepareStatement("ANALYZE " + tableName + " (" + cols.mkString(",") + ")")) { stmt =>
         stmt.execute()
       }
+      computeStatistics(conn)
+    } else {
+      preload.copy(added = totalAdded, deleted = totalDeleted)
     }
   }
 }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/Sqlizer.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/Sqlizer.scala
@@ -26,7 +26,7 @@ trait DataSqlizer[CT, CV] extends ReadDataSqlizer[CT, CV] {
   type PreloadStatistics
 
   def computeStatistics(conn: Connection): PreloadStatistics
-  def updateStatistics(conn: Connection, rowsAdded: Long, rowsDeleted: Long, rowsChanged: Long, preload: PreloadStatistics)
+  def updateStatistics(conn: Connection, rowsAdded: Long, rowsDeleted: Long, rowsChanged: Long, preload: PreloadStatistics): PreloadStatistics
 
   def softMaxBatchSize: Int
   def sizeofDelete(id: CV): Int


### PR DESCRIPTION
I think the problem with the last one is that I didn't take into
account the fact that batch size gets smaller (in terms of rows) as
datasets get wider.  So instead let's (a) keep track of _row counts_
instead of _batches_ and (b) decrease the frequency of ANALYZEs we
issue as datasets get larger, so that we only redo them if the row
count changes by a significant amount (25% of the total row count or
10000 rows, whichever is larger).