### PR TITLE
EN-19395: Get PostgresDatasetMapWriterTest running

### DIFF
--- a/coordinatorlib/src/it/scala/com/socrata/datacoordinator/truth/metadata/sql/PostgresDatasetMapWriterTest.scala
+++ b/coordinatorlib/src/it/scala/com/socrata/datacoordinator/truth/metadata/sql/PostgresDatasetMapWriterTest.scala
@@ -80,7 +80,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
   }
 
   override def beforeAll(): Unit = {
-    withPostgresDb(s"DROP DATABASE IF EXISTS $dbName; CREATE DATABASE $dbName encoding=UTF8;")
+    withPostgresDb(s"DROP DATABASE IF EXISTS $dbName; CREATE DATABASE $dbName;")
     withDb() { conn => populateDatabase(conn) }
     super.beforeAll()
   }


### PR DESCRIPTION
Get PostgresDatasetMapWriterTest running on Jenkins.
There seems to be a syntax error around encoding=UTF8
when the test is run on Jenkins.