### PR TITLE
EN-19241: FB secondary nolonger tracks primary key

### DIFF
--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20171020-migrate-geo-secondary-cookie-pk-to-sid.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20171020-migrate-geo-secondary-cookie-pk-to-sid.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+    http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
+    <changeSet author="Alexa Rust" id="20171020-migrate-geo-secondary-cookie-pk-to-sid">
+        <sql>
+            UPDATE secondary_manifest
+               SET cookie = regexp_replace(cookie,
+                                           '"primaryKey":".*?"',
+                                           '"systemId":":id"')
+             WHERE store_id = 'geocoding';
+        </sql>
+        <rollback>
+            UPDATE secondary_manifest
+               SET cookie = replace(cookie,
+                                    '"systemId":":id"',
+                                    '"primaryKey":":id"')
+             WHERE store_id = 'geocoding';
+        </rollback>
+    </changeSet>
+</databaseChangeLog>

--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/migrate.xml
@@ -31,6 +31,7 @@
     <include file="com.socrata.datacoordinator.truth.schema/20170615-add-dataset-map-resource-name-index.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20170915-migrate-geocoding-secondary-cookie.xml"/>
     <include file="com.socrata.datacoordinator.truth.schema/20171009-add-column-map-geo-modifiers.xml"/>
+    <include file="com.socrata.datacoordinator.truth.schema/20171020-migrate-geo-secondary-cookie-pk-to-sid.xml"/>
 
     <!-- run-on-change migrations: recreation of triggers typically comes after other changes that they may depend on -->
     <include file="com.socrata.datacoordinator.truth.schema/triggers/update-dataset-log-trigger.xml"/>


### PR DESCRIPTION
FeedbackSecondary no longer tracks primary key column of datasets,
but just uses the system id.

Migration to reflect changes in the cookie. This migration will
require down time for the geocoding-secondary (i.e. take the
secondary down, run the migration, then start the secondary on
the new version).

The rollback for the migration is not a perfect rollback since it
sets the primary key as the system id :id regardless if that is
true, but it is a good enough recoverable state and safer to run.