### PR TITLE
EN-19241: Fix FeedbackSecondary library

### DIFF
--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
@@ -287,7 +287,10 @@ class FeedbackContext[CT,CV](user: String,
     if (targetColumns.nonEmpty) {
       log.info("Computing columns: {}", targetColumns)
       val sourceColumns = targetColumns.map(cookie.strategyMap(_)).flatMap(_.sourceColumnIds).toSet.toSeq // .toSet for uniqueness
-      val columns = if (sourceColumns.nonEmpty) sourceColumns else Seq(cookie.systemId) // for when computed columns don't have any source columns
+      // always ask for the system id for two reasons:
+      //  - if the dataset has a user primary key, the system id will not be automatically returned
+      //  - if the computed columns don't have any source columns, we still need the system id column
+      val columns = Seq(cookie.systemId) ++ sourceColumns
 
       dataCoordinatorClient.exportRows(columns, cookie) match {
         case Right(Right(RowData(_, rows))) =>


### PR DESCRIPTION
Always export the system id column from data-coordinator
since if the dataset has a user primary key column set
data-coordinator will not return the system id column
by default. This is because now FeedbackSecondary
nows does everything by system id and not by primary key.

Fixes bug where system id column is not found in export
from data-coordinator when a user primary key is set
on the dataset. Introduced in commit:
2c58c73e4abb6bc50f0f91bd53da350be8f0f896