### PR TITLE
Avoid tight spin loop if we have errors updating SW claims.

### DIFF
--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -240,6 +240,8 @@ class SecondaryWatcher[CT, CV](universe: => Managed[SecondaryWatcher.UniverseTyp
         case e: Exception =>
           log.error("Unexpected exception while updating claimedAt time for secondary sync jobs claimed by watcherId " +
                     claimantId.toString(), e)
+          // avoid tight spin loop if we have recurring errors, eg. unable to talk to db
+          Thread.sleep(10L * 1000)
       }
     }
   }


### PR DESCRIPTION
The immediate motivation for this is that when I'm running secondary
watcher locally and sleep my laptop for a while, when it comes back
the connection pool is closed for some reason and secondary watcher
spins in a tight loop trying to update claims.  Hopefully the root
cause of this will be easier to figure out without the tight spin
loop.

Spinning in this loop is also something we could see in production
if the truth database is unavailable, etc.