### PR TITLE
EN-20087: Stop FeedbackSecondary OOMing on export

### DIFF
--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/DataCoordinatorClient.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/DataCoordinatorClient.scala
@@ -2,27 +2,31 @@ package com.socrata.datacoordinator.secondary.feedback
 
 import java.io.IOException
 
-import com.rojoma.json.v3.ast.{JString, JObject, JValue, JArray}
+import com.rojoma.json.util.JsonArrayIterator.ElementDecodeException
+import com.rojoma.json.v3.ast.{JArray, JObject, JString, JValue}
 import com.rojoma.json.v3.codec.{DecodeError, JsonDecode}
-import com.rojoma.json.v3.io.{JValueEventIterator, JsonReaderException}
-import com.rojoma.json.v3.util.{JsonUtil, NoTag, SimpleHierarchyCodecBuilder, AutomaticJsonCodecBuilder}
+import com.rojoma.json.v3.io.{JValueEventIterator, JsonLexException, JsonReaderException}
+import com.rojoma.json.v3.util._
+import com.rojoma.simplearm.v2.ResourceScope
 import com.socrata.datacoordinator.id.UserColumnId
 import com.socrata.datacoordinator.secondary
 import com.socrata.datacoordinator.util.collection.MutableColumnIdMap
 import com.socrata.http.client.{HttpClient, RequestBuilder, SimpleHttpRequest}
-import com.socrata.http.client.exceptions.{HttpClientException, ContentTypeException}
+import com.socrata.http.client.exceptions.{ContentTypeException, HttpClientException}
 
 case class RowData[CV](pk: UserColumnId, rows: Iterator[secondary.Row[CV]])
 
 abstract class DataCoordinatorClient[CT, CV](typeFromJValue: JValue => Option[CT],
                                              datasetInternalName: String,
                                              fromJValueFunc: CT => JValue => Option[CV]) {
+
   /**
    * Export the rows of a dataset for the given columns
    * @param columnSet must contain at least on column
    */
   def exportRows(columnSet: Seq[UserColumnId],
-                 cookie: CookieSchema): Either[RequestFailure, Either[ColumnsDoNotExist, RowData[CV]]]
+                 cookie: CookieSchema,
+                 resourceScope: ResourceScope): Either[RequestFailure, Either[ColumnsDoNotExist, RowData[CV]]]
 
   /**
    * Post mutation script to data-coordinator
@@ -69,8 +73,8 @@ class HttpDataCoordinatorClient[CT,CV](httpClient: HttpClient,
     Left(UnexpectedError(message, cause))
   }
 
-  private def unexpectedErrorForResponse(message: String, code: Int, info: Any) =
-    unexpectedError(s"$message from data-coordinator for status $code: $info")
+  private def unexpectedErrorForResponse(message: String, code: Int, info: Any, cause: Exception = null) =
+    unexpectedError(s"$message from data-coordinator for status $code: $info", cause)
 
   private val unexpected = "Received an unexpected error"
   private val uninterpretable = "Unable to interpret error response"
@@ -107,54 +111,52 @@ class HttpDataCoordinatorClient[CT,CV](httpClient: HttpClient,
 
   private def doRequest[T](request: SimpleHttpRequest,
                            message: String,
-                           successHandle: JArray => Either[UnexpectedError, T],
+                           successHandle: Iterator[JValue]=> Either[UnexpectedError, T],
                            badRequestHandle: ErrorResponse => Either[UnexpectedError, T],
-                           serverErrorMessageExtra: String): Either[RequestFailure, T] = {
+                           serverErrorMessageExtra: String,
+                           resourceScope: ResourceScope): Either[RequestFailure, T] = {
     retrying[T] {
-      httpClient.execute(request).run { resp =>
-        val start = System.nanoTime()
-        def logContentTypeFailure(v: => JValue)(f: JValue => Either[RequestFailure, T]): Either[RequestFailure, T] =
-          try {
-            f(v)
-          } catch {
-            case e: ContentTypeException =>
-              log.warn("The response from data-coordinator was not a valid JSON content type! The request we sent was: {}", request.toString)
+      val resp = httpClient.execute(request, resourceScope)
+      val start = System.nanoTime()
+      def logContentTypeFailure[V](v: => JValue)(f: JValue => Either[RequestFailure, T]): Either[RequestFailure, T] =
+        try {
+          f(v)
+        } catch {
+          case e: ContentTypeException =>
+            log.warn("The response from data-coordinator was not a valid JSON content type! The request we sent was: {}", request.toString)
               unexpectedError("Unable to understand data-coordinator's response", e) // no retry here
-          }
-
-        resp.resultCode match {
-          case 200 =>
-            // success! ... well maybe...
-            val end = System.nanoTime()
-            log.info("{} in {}ms", message, (end - start) / 1000000)
-            logContentTypeFailure(resp.jValue()) { JsonDecode.fromJValue[JArray](_) match {
-              case Right(response) => successHandle(response)
-              case Left(e) => unexpectedError(s"Response from data-coordinator was not an array: ${e.english}")
-            }}
-          case 400 =>
-            logContentTypeFailure(resp.jValue()) { JsonDecode.fromJValue[ErrorResponse](_) match {
-              case Right(response) => badRequestHandle(response)
-              case Left(e) => uninterpretableResponse(400, e)
-            }}
-          case 404 =>
-            // { "errorCode" : "update.dataset.does-not-exist"
-            // , "data" : { "dataset" : "XXX.XXX, "data" : { "commandIndex" : 0 }
-            // }
-            logContentTypeFailure(resp.jValue()) { JsonDecode.fromJValue[ErrorResponse](_) match {
-              case Right(ErrorResponse(UpdateDatasetDoesNotExist, _)) => Left(DatasetDoesNotExist)
-              case Right(response) => unexpectedResponse(404, response)
-              case Left(e) => uninterpretableResponse(404, e)
-            }}
-          case 409 =>
-            // come back later!
-            Left(DataCoordinatorBusy) // no retry
-          case other =>
-            if (other == 500) {
-              log.warn("Scream! 500 from data-coordinator! Going to retry; {}", serverErrorMessageExtra)
-            }
-            // force a retry
-            throw new IOException(s"Unexpected result code $other from data-coordinator")
         }
+
+      resp.resultCode match {
+        case 200 =>
+          // success! ... well maybe...
+          val end = System.nanoTime()
+          log.info("{} in {}ms", message, (end - start) / 1000000) // this is kind of a lie... hmm
+          val response = JsonArrayIterator.fromReader[JValue](resp.reader())
+          successHandle(resourceScope.openUnmanaged(response, transitiveClose = List(resp)))
+        case 400 =>
+          logContentTypeFailure(resp.jValue()) { JsonDecode.fromJValue[ErrorResponse](_) match {
+            case Right(response) => badRequestHandle(response)
+            case Left(e) => uninterpretableResponse(400, e)
+          }}
+        case 404 =>
+          // { "errorCode" : "update.dataset.does-not-exist"
+          // , "data" : { "dataset" : "XXX.XXX, "data" : { "commandIndex" : 0 }
+          // }
+          logContentTypeFailure(resp.jValue()) { JsonDecode.fromJValue[ErrorResponse](_) match {
+            case Right(ErrorResponse(UpdateDatasetDoesNotExist, _)) => Left(DatasetDoesNotExist)
+            case Right(response) => unexpectedResponse(404, response)
+            case Left(e) => uninterpretableResponse(404, e)
+          }}
+        case 409 =>
+          // come back later!
+          Left(DataCoordinatorBusy) // no retry
+        case other =>
+          if (other == 500) {
+            log.warn("Scream! 500 from data-coordinator! Going to retry; {}", serverErrorMessageExtra)
+          }
+          // force a retry
+          throw new IOException(s"Unexpected result code $other from data-coordinator")
       }
     }
   }
@@ -169,27 +171,29 @@ class HttpDataCoordinatorClient[CT,CV](httpClient: HttpClient,
    * Export the rows of a dataset for the given columns
    * @param columnSet must contain at least on column
    */
-  def exportRows(columnSet: Seq[UserColumnId], cookie: CookieSchema): Either[RequestFailure, Either[ColumnsDoNotExist, RowData[CV]]] = {
+  def exportRows(columnSet: Seq[UserColumnId],
+                 cookie: CookieSchema,
+                 resourceScope: ResourceScope): Either[RequestFailure, Either[ColumnsDoNotExist, RowData[CV]]] = {
     require(columnSet.nonEmpty, "`columnSet` must be non-empty")
     log.info("Exporting rows for columns: {}", columnSet)
     val endpoint = datasetEndpoint.getOrElse(return Left(FailedToDiscoverDataCoordinator))
     val columns = columnSet.tail.foldLeft(columnSet.head.underlying) { (str, id) => str + "," + id.underlying }
     val builder = RequestBuilder(new java.net.URI(endpoint)).addParameter(("c", columns))
 
-    def successHandle(response: JArray): Either[UnexpectedError, Either[ColumnsDoNotExist, RowData[CV]]] = {
+    def successHandle(response: Iterator[JValue]): Either[UnexpectedError, Either[ColumnsDoNotExist, RowData[CV]]] = {
       if (response.isEmpty) return unexpectedError("Response from data-coordinator was an empty array.")
 
-      JsonDecode.fromJValue[Schema](response.head) match {
+      JsonDecode.fromJValue[Schema](response.next()) match {
         case Right(Schema(pk, schema)) =>
           val columns = schema.map { col =>
             (cookie.columnIdMap(col.c), typeFromJValue(col.t).getOrElse {
               return unexpectedError(s"Could not derive column type for column ${col.c} from value: ${col.t}")
             })
           }.toArray
-          val rows = response.tail.iterator.map {
+          val rows = response.map {
             JsonDecode.fromJValue[JArray](_) match {
               case Right(row) =>
-                assert(row.size == columns.size)
+                assert(row.size == columns.length)
                 val colIdMap = new MutableColumnIdMap[CV]
                 row.iterator.zipWithIndex.foreach { case (jVal, index) =>
                   val (colId, typ) = columns(index)
@@ -201,7 +205,7 @@ class HttpDataCoordinatorClient[CT,CV](httpClient: HttpClient,
               case Left(e) => return unexpectedErrorForResponse("Row data was not an array", 200, e.english)
             }
           }
-          Right(Right(RowData(pk, rows)))
+          Right(Right(resourceScope.openUnmanaged(RowData(pk, rows), transitiveClose = List(response))))
         case Left(e) => unexpectedErrorForResponse("Response did not start with expected column schema", 200, e.english)
       }
     }
@@ -220,7 +224,8 @@ class HttpDataCoordinatorClient[CT,CV](httpClient: HttpClient,
       message = s"Got row data for columns $columns",
       successHandle,
       badRequestHandle,
-      serverErrorMessageExtra = s"my parameters where: c=$columns"
+      serverErrorMessageExtra = s"my parameters where: c=$columns",
+      resourceScope
     )
   }
 
@@ -233,28 +238,35 @@ class HttpDataCoordinatorClient[CT,CV](httpClient: HttpClient,
   implicit val reCodec = SimpleHierarchyCodecBuilder[Response](NoTag).branch[Upsert].branch[NonfatalError].build
 
   override def postMutationScript(script: JArray, cookie: CookieSchema): Option[Either[RequestFailure, UpdateSchemaFailure]] = {
+    val resourceScope = new ResourceScope("post mutation script")
+
     val endpoint = datasetEndpoint.getOrElse(return Some(Left(FailedToDiscoverDataCoordinator)))
     val builder = RequestBuilder(new java.net.URI(endpoint))
 
     def body = JValueEventIterator(script)
 
-    def successHandle(response: JArray): Either[UnexpectedError, Option[UpdateSchemaFailure]] = {
-      assert(response.elems.length == 1, "Response contains more than one element")
-      JsonDecode.fromJValue[JArray](response.elems.head) match {
-        case Right(results) =>
-          assert(results.elems.length == script.elems.length - 2, "Did not get one result for each upsert command that was sent")
-          val rows = script.elems.slice(2, script.elems.length)
-          results.elems.zip(rows).foreach { case (result, row) =>
-            JsonDecode.fromJValue[Response](result) match {
-              case Right(Upsert("update", _, _)) => // yay!
-              case Right(NonfatalError("error", nonfatalError, Some(_))) if nonfatalError == "insert_in_update_only" ||  nonfatalError == "no_such_row_to_update" =>
+    def successHandle(response: Iterator[JValue]): Either[UnexpectedError, Option[UpdateSchemaFailure]] = {
+      try {
+        assert(response.hasNext, "Response contains more than one element")
+        JsonDecode.fromJValue[JArray](response.next) match {
+          case Right(results) =>
+            assert(results.elems.length == script.elems.length - 2, "Did not get one result for each upsert command that was sent")
+            val rows = script.elems.slice(2, script.elems.length)
+            results.elems.zip(rows).foreach { case (result, row) =>
+              JsonDecode.fromJValue[Response](result) match {
+                case Right(Upsert("update", _, _)) => // yay!
+                case Right(NonfatalError("error", nonfatalError, Some(_))) if nonfatalError == "insert_in_update_only" || nonfatalError == "no_such_row_to_update" =>
                 // the row has been deleted, nothing more to do here
-              case Right(other) => unexpectedErrorForResponse("Unexpected response in array", 200, other)
-              case Left(e) => unexpectedErrorForResponse("Unable to interpret result in array", 200, e.english)
+                case Right(other) => unexpectedErrorForResponse("Unexpected response in array", 200, other)
+                case Left(e) => unexpectedErrorForResponse("Unable to interpret result in array", 200, e.english)
+              }
             }
-          }
-          Right(None)
-        case Left(e) => unexpectedErrorForResponse("Row data was not an array", 200, e.english)
+            Right(None)
+          case Left(e) => unexpectedErrorForResponse("Row data was not an array", 200, e.english)
+        }
+      } catch {
+        case e: JsonLexException => unexpectedErrorForResponse("Unable to parse response as JSON", 200, e.message, e)
+        case e: ElementDecodeException => unexpectedErrorForResponse("Unable to parse an element of the response as JSON", 200, e.position, e)
       }
     }
 
@@ -272,16 +284,20 @@ class HttpDataCoordinatorClient[CT,CV](httpClient: HttpClient,
       }
     }
 
-    doRequest(
+    val requestResult = doRequest(
       request = builder.json(body),
       message = s"Posted mutation script with ${script.length - 2} row updates",
       successHandle,
       badRequestHandle,
-      serverErrorMessageExtra = s"my mutation script was: ${JsonUtil.renderJson(script, pretty = false)}"
+      serverErrorMessageExtra = s"my mutation script was: ${JsonUtil.renderJson(script, pretty = false)}",
+      resourceScope
     ) match {
       case Left(failure) => Some(Left(failure))
       case Right(Some(failure)) => Some(Right(failure))
       case Right(None) => None
     }
+    resourceScope.close()
+
+    requestResult
   }
 }

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
@@ -147,7 +147,7 @@ class FeedbackContext[CT,CV](user: String,
           if (filtered.nonEmpty) {
             val newRow = Map(
               cookie.systemId -> rowId
-            ) ++ filtered.map { case (id, value) => (id, value) }.toMap
+            ) ++ filtered
             Some(rowIdx -> newRow)
           } else {
             None

--- a/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondaryTest.scala
+++ b/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondaryTest.scala
@@ -31,7 +31,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
   }
 
   def expectNoDataCoordinatorCalls(mockDC: DataCoordinatorClient[SoQLType, SoQLValue]): Unit = {
-    (mockDC.exportRows _).expects(*, *).never
+    (mockDC.exportRows _).expects(*, *, *).never
     (mockDC.postMutationScript _).expects(*, *).never
   }
 
@@ -140,7 +140,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called for a version with a new computed column exporting no row data" should {
       withMockDC("export no rows and return the expected cookie", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.systemPKEmpty)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.systemPKEmpty)
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
         shouldBe(secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events), TestCookie.v3)
@@ -149,7 +149,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called for a version with a new computed column with unexpected error with DC client" should {
       withMockDC("should throw an Exception", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.unexpectedError)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.unexpectedError)
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
         val caught = intercept[Exception] {
@@ -161,7 +161,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called for a version with a new computed column and failed to discover DC" should {
       withMockDC("throw a ReplayLaterException", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.failedToDiscoverDC)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.failedToDiscoverDC)
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
         val caught = intercept[ReplayLaterSecondaryException] {
@@ -175,7 +175,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called for a version with a new computed column and dataset busy" should {
       withMockDC("throw a ReplayLaterException", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.dataCoordinatorBusy)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.dataCoordinatorBusy)
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
         val caught = intercept[ReplayLaterSecondaryException] {
@@ -189,7 +189,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called for a version with a new computed column and it and the source column have been deleted" should {
       withMockDC("return the expected cookie", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.num1DoesNotExist)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.num1DoesNotExist)
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
         shouldBe(secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events), TestCookie.v3almost5)
@@ -200,7 +200,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called for a version with a new computed column exporting row data" should {
       withMockDC("export rows in batches and return the expected cookie", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.systemPKNum1Num2)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.systemPKNum1Num2)
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.success)
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(1), TestCookie.v3Schema).once.returning(TestScripts.success)
@@ -211,7 +211,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called for a version with a new computed column target column deleted before post" should {
       withMockDC("export rows in batches and return the expected cookie", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.systemPKNum1Num2)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.systemPKNum1Num2)
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.success)
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(1), TestCookie.v3Schema).once.returning(TestScripts.sum12DoesNotExist)
@@ -222,7 +222,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called and receives an unexpected error when posting a mutation script" should {
       withMockDC("throw a ReplayLaterException", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.systemPKNum1Num2)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.systemPKNum1Num2)
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.unexpectedError)
       }) { case (secondary, cookie) =>
@@ -238,7 +238,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called and failed to discover DC when posting a mutation script" should {
       withMockDC("throw a ReplayLaterException", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.systemPKNum1Num2)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.systemPKNum1Num2)
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.failedToDiscoverDC)
       }) { case (secondary, cookie) =>
@@ -253,7 +253,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called and data-coordinator busy when posting a mutation script" should {
       withMockDC("throw a ReplayLaterException", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.systemPKNum1Num2)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.systemPKNum1Num2)
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.dataCoordinatorBusy)
       }) { case (secondary, cookie) =>
@@ -268,7 +268,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called and the dataset does not exist when posting a mutation script" should {
       withMockDC("succeed and return the expected cookie", TestCookie.v2, { mockDC =>
         // on flushing the new computed column, rows should be exported once
-        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema).once.returning(TestRows.systemPKNum1Num2)
+        (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.systemPKNum1Num2)
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.doesNotExist)
       }) { case (secondary, cookie) =>
@@ -297,7 +297,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called for a version containing updates to a source column" should {
       withMockDC("post rows in batches and return the expected cookie", TestCookie.v9, { mockDC =>
         // should not export any rows
-        (mockDC.exportRows _).expects(*, *).never
+        (mockDC.exportRows _).expects(*, *, *).never
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum23ScriptsV11(0), TestCookie.v10Schema).once.returning(TestScripts.success)
         (mockDC.postMutationScript _).expects(TestScripts.sum23ScriptsV11(1), TestCookie.v10Schema).once.returning(TestScripts.success)
@@ -327,7 +327,7 @@ class FeedbackSecondaryTest extends WordSpec with ShouldMatchers with MockFactor
     "called with random string cookie on the latest living copy where updates are needed" should {
       withMockDC("post batches to DC and return the expected cookie", None, { mockDC =>
         // should not export any rows
-        (mockDC.exportRows _).expects(*, *).never
+        (mockDC.exportRows _).expects(*, *, *).never
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum23ScriptsV11(0), TestCookie.v10Schema).once.returning(TestScripts.success)
         (mockDC.postMutationScript _).expects(TestScripts.sum23ScriptsV11(1), TestCookie.v10Schema).once.returning(TestScripts.success)


### PR DESCRIPTION
Fix FeedbackSecondary library code to properly use an iterator
when exporting row data from data-coordinator to avoid OOMing
on large datasets.