### PR TITLE
EN-5487: Support delete on S-M for "full" stores

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/DatasetSecondaryStatusResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/DatasetSecondaryStatusResource.scala
@@ -10,6 +10,7 @@ import com.socrata.http.server.implicits._
 case class DatasetSecondaryStatusResource(storeIdOpt: Option[String],
                                           datasetId: DatasetId,
                                           secondaries: Set[String],
+                                          secondariesNotAcceptingNewDatasets: Set[String],
                                           versionInStore: (String, DatasetId) => Option[Long],
                                           serviceConfig: ServiceConfig,
                                           ensureInSecondary: (String, DatasetId) => Boolean,
@@ -51,6 +52,7 @@ case class DatasetSecondaryStatusResource(storeIdOpt: Option[String],
     val found = storeId match {
       case "_DEFAULT_" => defaultSecondaryGroups.toVector.map(ensureInSecondaryGroup(_, datasetId)).forall(identity) // no side effects in forall
       case groupRe(g) if serviceConfig.secondary.groups.contains(g) => ensureInSecondaryGroup(g, datasetId)
+      case _ if secondariesNotAcceptingNewDatasets(storeId) => return Forbidden
       case secondary if secondaries(storeId) => ensureInSecondary(secondary, datasetId)
       case _ => false
     }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/config/SecondaryConfig.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/config/SecondaryConfig.scala
@@ -10,7 +10,8 @@ import net.ceedubs.ficus.FicusConfig._
 
 case class SecondaryGroupConfig(
      numReplicas: Int,
-     instances: Set[String]
+     instances: Set[String],
+     instancesNotAcceptingNewDatasets: Option[Set[String]]
  )
 
 case class SecondaryInstanceConfig(


### PR DESCRIPTION
Support delete on /secondary-manifest for "full" stores or stores we
other wise have decided we do not want to send new datasets to.

Add configuration for specifying instances in a secondary group
that are not accepting new datasets. With this change, we will
not remove secondary instances in a group from data-coordinator's
config that are full, but instead add them to the set of instances
not accepting new datasets for the group in question.

This fixes delete not working on /secondary-manifest for full stores
that have been removed from data-coordinator's config by not removing
them from data-coordinator's config to start with.

This will also support data-coordinator's future collocation logic
to be able to know about all instances in a secondary group, but
still know about which stores have been backlisted as too full
to move datasets to.