### PR TITLE
SPARTA: For local dev use naming in onramp script

### DIFF
--- a/configs/sample-data-coordinator.conf
+++ b/configs/sample-data-coordinator.conf
@@ -2,7 +2,7 @@ com.socrata.coordinator.common = {
   database = {
     host = "localhost"
     port = 5432
-    database = "datacoordinator_alpha"
+    database = "datacoordinator"
     username = "blist"
     password = "blist"
   }
@@ -11,10 +11,10 @@ com.socrata.coordinator.common = {
   # data coordinator.  It doesn't have any semantic meaning but it is used
   # to form the internal names of datasets and to advertise the server
   # in zookeeper.
-  instance = alpha
+  instance = primus
 
   collocation {
-    group = [alpha]
+    group = [primus]
     lock-path = "collocation-lock"
     lock-timeout = 10s // TODO: ???
   }


### PR DESCRIPTION
For sample local dev configuration use database name
`datacoordinator` and instance name `primus` to match
existing setup of local dev environments done by the
onramp script.