### PR TITLE
EN-17025: Fix insert into collocation manifest

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/PostgresCollocationManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/PostgresCollocationManifest.scala
@@ -1,0 +1,67 @@
+package com.socrata.datacoordinator.secondary.sql
+
+import java.sql.{Connection, SQLException}
+
+import com.rojoma.simplearm.util.using
+
+class PostgresCollocationManifest(conn: Connection) extends SqlCollocationManifest(conn) {
+
+  private val log = org.slf4j.LoggerFactory.getLogger(classOf[PostgresCollocationManifest])
+
+  private val uniqueViolation = "23505"
+
+  override def addCollocations(collocations: Set[(String, String)]): Unit = {
+    val defaultAutoCommit = conn.getAutoCommit
+    try {
+      // I think this is not needed because auto commit is already false... but
+      // set auto commit to false for doing batch inserts
+      conn.setAutoCommit(false)
+
+      using(conn.prepareStatement("SHOW server_version_num")) { showVersion =>
+        using(showVersion.executeQuery()) { version =>
+          if (version.getInt("server_version_num") < 90500) { // I know I am a terrible human...
+            // TODO: delete this case when we no longer have Postgres 9.4 servers running
+            collocations.foreach { case (left, right) =>
+              val savepoint = conn.setSavepoint()
+              try {
+                using(conn.prepareStatement(
+                  """INSERT INTO collocation_manifest (dataset_internal_name_left, dataset_internal_name_right)
+                    |     VALUES (? , ?)""".stripMargin)) { insert =>
+                  insert.setString(1, left)
+                  insert.setString(2, right)
+                  insert.execute()
+                }
+              } catch {
+                case e: java.sql.SQLException if e.getSQLState == uniqueViolation =>
+                  conn.rollback(savepoint)
+              } finally {
+                try {
+                  conn.releaseSavepoint(savepoint)
+                } catch {
+                  case e: SQLException =>
+                    log.warn("Unexpected exception while releasing savepoint", e)
+                }
+              }
+            }
+          } else {
+            // server is running at least Postgres 9.5 and ON CONFLICT is supported
+            using(conn.prepareStatement(
+              """INSERT INTO collocation_manifest (dataset_internal_name_left, dataset_internal_name_right)
+                |     VALUES (? , ?)
+                |ON CONFLICT DO NOTHING""".stripMargin)) { insert =>
+              collocations.foreach { case (left, right) =>
+                insert.setString(1, left)
+                insert.setString(2, right)
+                insert.addBatch()
+              }
+
+              insert.executeBatch()
+            }
+          }
+        }
+      }
+    } finally {
+      conn.setAutoCommit(defaultAutoCommit)
+    }
+  }
+}

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/PostgresUniverse.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/PostgresUniverse.scala
@@ -13,10 +13,10 @@ import com.socrata.datacoordinator.truth.metadata._
 import com.socrata.datacoordinator.truth.sql.{PostgresDatabaseMutator, PostgresDatabaseReader, RepBasedSqlDatasetContext, SqlColumnRep}
 import com.socrata.datacoordinator.truth._
 import com.socrata.datacoordinator.truth.metadata.sql._
-import com.socrata.datacoordinator.secondary.{CollocationManifest, PlaybackToSecondary, SecondaryMoveJobs, SecondaryManifest, SecondaryReplicationMessages}
+import com.socrata.datacoordinator.secondary._
 import com.socrata.datacoordinator.truth.loader._
 import com.socrata.datacoordinator.truth.loader.sql._
-import com.socrata.datacoordinator.secondary.sql.{SqlCollocationManifest, SqlSecondaryMoveJobs, SqlSecondaryManifest, SqlSecondaryStoresConfig}
+import com.socrata.datacoordinator.secondary.sql._
 import com.socrata.datacoordinator.util._
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
 import org.slf4j.LoggerFactory
@@ -157,7 +157,7 @@ class PostgresUniverse[ColumnType, ColumnValue](conn: Connection,
     new SqlSecondaryManifest(conn)
 
   lazy val collocationManifest: CollocationManifest =
-  new SqlCollocationManifest(conn)
+    new PostgresCollocationManifest(conn)
 
   lazy val secondaryMoveJobs: SecondaryMoveJobs =
     new SqlSecondaryMoveJobs(conn)


### PR DESCRIPTION
Fix insert into collocation manifest as part of executing
collocation. ON CONFLICT in INSERT statements is not supported
until PostgreSQL 9.5 but we are still running some truth
servers on PostgreSQL 9.4.