### PR TITLE
EN-21355: Remove extra '.' in collocation error

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/SoQLCommon.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/SoQLCommon.scala
@@ -84,7 +84,7 @@ class SoQLCommon(dataSource: DataSource,
     internalNamePrefix + datasetId.underlying
 
   def datasetInternalNameFromDatasetId(datasetId: DatasetId): DatasetInternalName =
-    DatasetInternalName(internalNamePrefix, datasetId)
+    DatasetInternalName(instance, datasetId)
 
   val datasetMapLimits = StandardDatasetMapLimits
 


### PR DESCRIPTION
Remove extra '.' from dataset internal name in data-coordinator's
collocation error responses.