### PR TITLE
EN-21740: Fix collocation by fixing explain

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
@@ -144,7 +144,7 @@ class CoordinatedCollocator(collocationGroup: Set[String],
 
               // we will 404 if we get a 404 projected stores for one of the input datasets
               val datasetStoresMap = inputDatasets.map { dataset =>
-                if (instances(dataset.instance)) {
+                if (collocationGroup(dataset.instance)) {
                   (dataset, stores(storeGroup, dataset, instances, replicationFactor))
                 } else {
                   log.warn("Unable to find dataset {} since it has an unrecognized instance name!", dataset)

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Coordinator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Coordinator.scala
@@ -34,7 +34,7 @@ case class StoreNotFound(name: String) extends ResourceNotFound(name, "secondary
 case class DatasetNotFound(internalName: DatasetInternalName) extends ResourceNotFound(internalName.underlying, "dataset")
 
 trait Coordinator {
-  val secondaryGroups: Map[String, SecondaryGroupConfig]
+  def secondaryGroups: Map[String, SecondaryGroupConfig]
   def collocatedDatasetsOnInstance(instance: String, datasets: Set[DatasetInternalName]): Either[RequestError, CollocatedDatasetsResult]
   def secondariesOfDataset(internalName: DatasetInternalName): Either[RequestError, Option[SecondariesOfDatasetResult]]
   def secondaryMoveJobs(storeGroup: String, internalName: DatasetInternalName): Either[ErrorResult, SecondaryMoveJobsResult]


### PR DESCRIPTION
Fix explain by comparing dataset instance name
to actual data-coordinator instance names.

Also add a couple basic unit test for explainCollocation
asserting fixed behavior. (See EN-21688)