### PR TITLE
EN-21910: Pass JobId for Collocation

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/collocation/SecondaryManifestsCollocateResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/collocation/SecondaryManifestsCollocateResource.scala
@@ -16,7 +16,7 @@ case class SecondaryManifestsCollocateResource(storeGroup: String,
 
   private def doCollocateDatasets(req: HttpRequest): HttpResponse = {
     withBooleanParam("explain", req) { explain =>
-      withTypedParam("job", req, UUID.randomUUID) { jobId =>
+      withUUIDParam("job", req) { jobId =>
         withPostBody[CollocationRequest](req) { request =>
           try {
             log.info("Beginning collocation request for job {}", jobId)

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/collocation/SecondaryManifestsCollocateResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/collocation/SecondaryManifestsCollocateResource.scala
@@ -16,27 +16,28 @@ case class SecondaryManifestsCollocateResource(storeGroup: String,
 
   private def doCollocateDatasets(req: HttpRequest): HttpResponse = {
     withBooleanParam("explain", req) { explain =>
-      withPostBody[CollocationRequest](req) { request =>
-        val jobId = UUID.randomUUID()
-        try {
-          log.info("Beginning collocation request for job {}", jobId)
-          coordinator.collocator.beginCollocation()
+      withTypedParam("job", req, UUID.randomUUID) { jobId =>
+        withPostBody[CollocationRequest](req) { request =>
+          try {
+            log.info("Beginning collocation request for job {}", jobId)
+            coordinator.collocator.beginCollocation()
 
-          val storeGroups = storeGroup match {
-            case "_DEFAULT_" => coordinator.collocator.defaultStoreGroups
-            case other => Set(other)
-          }
+            val storeGroups = storeGroup match {
+              case "_DEFAULT_" => coordinator.collocator.defaultStoreGroups
+              case other => Set(other)
+            }
 
-          doCollocationJob(jobId, storeGroups, request, explain) match {
-            case Right(result) => responseOK(result)
-            case Left(StoreGroupNotFound(group)) => storeGroupNotFound(group)
-            case Left(DatasetNotFound(dataset)) => datasetNotFound(dataset, BadRequest)
-            case Left(_) => InternalServerError
+            doCollocationJob(jobId, storeGroups, request, explain) match {
+              case Right(result) => responseOK(result)
+              case Left(StoreGroupNotFound(group)) => storeGroupNotFound(group)
+              case Left(DatasetNotFound(dataset)) => datasetNotFound(dataset, BadRequest)
+              case Left(_) => InternalServerError
+            }
+          } catch {
+            case _: CollocationLockTimeout => Conflict
+          } finally {
+            coordinator.collocator.commitCollocation()
           }
-        } catch {
-          case _: CollocationLockTimeout => Conflict
-        } finally {
-          coordinator.collocator.commitCollocation()
         }
       }
     }


### PR DESCRIPTION
Take collocation job id as a passed parameter rather than generating it in data-coordinator. This allows core to more easily maintain a manifest of collocations.