### PR TITLE
EN-22044: Explicit use of local.dev.socrata.net

### DIFF
--- a/configs/application.conf
+++ b/configs/application.conf
@@ -1,6 +1,6 @@
 # Sensible defaults for a development environment
-include "sample-data-coordinator.conf"
+include "sample.conf"
 
 # This file is .gitignored; you can create it and make
 # any changes you like there.
-include "local-data-coordinator.conf"
+include "local.conf"

--- a/configs/sample.conf
+++ b/configs/sample.conf
@@ -1,6 +1,10 @@
+# use local.dev.socrata.net to support solo which resolves to 127.0.0.1
+common-host = "local.dev.socrata.net"
+common-zk-ensemble = ["local.dev.socrata.net:2181"]
+
 com.socrata.coordinator.common = {
   database = {
-    host = "localhost"
+    host = ${common-host}
     port = 5432
     database = "datacoordinator"
     username = "blist"
@@ -42,7 +46,7 @@ com.socrata.coordinator.common = {
 }
 
 com.socrata.coordinator.service = ${com.socrata.coordinator.common} {
-  curator.ensemble = ["localhost:2181"]
+  curator.ensemble = ${common-zk-ensemble}
   network.port = 6020 # if you want to run more than one data-coordinator instance you will need to override this
   reports.directory = ${user.home}
 }


### PR DESCRIPTION
Clearly comment that it was for solo (becaus I was confused).
Also, a little bit of config renaming to match spandex based
off of code reviews there.