### PR TITLE
EN-21686: Add secondary-metrics API to Coordinator

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
@@ -580,6 +580,7 @@ object Main extends DynamicPortMap {
             new HttpClientHttpClient(executorService), // since executorService is currently unbounded we can share here
             operations.collocatedDatasets,
             operations.secondariesOfDataset,
+            operations.secondaryMetrics,
             operations.secondaryMoveJobs,
             operations.ensureSecondaryMoveJob,
             operations.rollbackSecondaryMoveJob

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Cost.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Cost.scala
@@ -26,5 +26,7 @@ object Cost {
 
   val Zero: Cost = Cost(moves = 0, totalSizeBytes = 0L, moveSizeMaxBytes = Some(0L))
 
-  val Unknown: Cost = Cost(moves = 1, totalSizeBytes = Long.MinValue)
+  // since we have not yet backfilled the secondary_metrics table and we don't want to
+  // outright fail, return an obviously not real value for the total size in bytes.
+  val Unknown: Cost = Cost(moves = 1, totalSizeBytes = -1L)
 }

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Cost.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Cost.scala
@@ -3,18 +3,28 @@ package com.socrata.datacoordinator.service.collocation
 import com.rojoma.json.v3.util.{AutomaticJsonEncodeBuilder, JsonKeyStrategy, Strategy}
 
 @JsonKeyStrategy(Strategy.Underscore)
-case class Cost(moves: Int) extends Ordered[Cost] {
+case class Cost(moves: Int, totalSizeBytes: Long, moveSizeMaxBytes: Option[Long] = None) extends Ordered[Cost] {
   override def compare(that: Cost): Int = {
     this.moves - that.moves
   }
 
+  def getMoveSizeMaxBytes: Long = this.moveSizeMaxBytes.getOrElse(this.totalSizeBytes)
+
   def +(that: Cost): Cost = {
-    Cost(moves = this.moves + that.moves)
+    Cost(
+      moves = this.moves + that.moves,
+      totalSizeBytes = this.totalSizeBytes + that.totalSizeBytes,
+      moveSizeMaxBytes = Some(Math.max(this.getMoveSizeMaxBytes, that.getMoveSizeMaxBytes))
+    )
   }
 }
 
 object Cost {
   implicit val encode = AutomaticJsonEncodeBuilder[Cost]
 
-  val Zero: Cost = Cost(moves = 0)
+  def max(x: Cost, y: Cost): Cost = Ordering[Cost].max(x, y)
+
+  val Zero: Cost = Cost(moves = 0, totalSizeBytes = 0L, moveSizeMaxBytes = Some(0L))
+
+  val Unknown: Cost = Cost(moves = 1, totalSizeBytes = Long.MinValue)
 }

--- a/coordinator/src/test/scala/com/socrata/datacoordinator/service/collocation/secondary/stores/SecondaryStoreSelectorTest.scala
+++ b/coordinator/src/test/scala/com/socrata/datacoordinator/service/collocation/secondary/stores/SecondaryStoreSelectorTest.scala
@@ -53,7 +53,7 @@ class SecondaryStoreSelectorTest extends FunSuite with ShouldMatchers {
     stores.intersect(destinations2) should have size 2
   }
 
-  val costMap = Map(0 -> Cost(4), 1 -> Cost(1), 2 -> Cost(1), 3 -> Cost(2))
+  val costMap = Map(0 -> Cost(4, 40), 1 -> Cost(1, 10), 2 -> Cost(1, 10), 3 -> Cost(2, 20))
   val storeMap = Map(0 -> Set(store1), 1 -> Set(store2), 2 -> Set(store3), 3 -> Set(store3))
 
   test("There should be a key for the max cost in a cost map") {


### PR DESCRIPTION
Add secondary-manifest/metrics endpoint to Coordinator service
to be used in explain and initiate of collocation by the Collocator
service.

Add the dataset size from the secondary-metrics API to Cost in
collocation, but don't do anything with it yet.