### PR TITLE
EN-17021: Fix insert into secondary_metrics

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/PostgresSecondaryMetrics.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/PostgresSecondaryMetrics.scala
@@ -29,7 +29,9 @@ class PostgresSecondaryMetrics(conn: Connection) extends SqlSecondaryMetrics(con
     // once we are no longer running 9.4 truth instances
     if (rowsUpdated == 0) {
       try {
-        using(conn.prepareStatement("INSERT INTO secondary_metrics (store_id, dataset_system_id, total_size) (?, ?, ?)")) { stmt =>
+        using(conn.prepareStatement(
+          """INSERT INTO secondary_metrics (store_id, dataset_system_id, total_size)
+            |     VALUES (?, ?, ?)""".stripMargin)) { stmt =>
           stmt.setString(1, storeId)
           stmt.setDatasetId(2, datasetId)
           stmt.setLong(3, metric.totalSizeBytes)


### PR DESCRIPTION
Fix insert into secondary_metrics table used by the SecondaryWatcher.