### PR TITLE
EN-22550: Drop entries from collocation manifests

### DIFF
--- a/coordinator-external/src/main/scala/com/socrata/datacoordinator/external/DataCoordinatorError.scala
+++ b/coordinator-external/src/main/scala/com/socrata/datacoordinator/external/DataCoordinatorError.scala
@@ -68,6 +68,7 @@ object CollocationError {
   val DATASET_NOT_FOUND_IN_STORE = "collocation.secondary.dataset-not-found-in-store"
 
   val INVALID_JOB_ID = "collocation.job.invalid-uuid"
+  val INVALID_DATASET_INTERNAL_NAME = "collocation.dataset.invalid-internal-name"
 }
 
 object SecondaryMetricsError {

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/collocation/CollocationManifestsResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/collocation/CollocationManifestsResource.scala
@@ -1,8 +1,10 @@
 package com.socrata.datacoordinator.resources.collocation
 
+import com.rojoma.json.v3.ast.JString
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, Strategy}
+import com.socrata.datacoordinator.external.CollocationError
 import com.socrata.datacoordinator.id.DatasetInternalName
-import com.socrata.datacoordinator.service.collocation.{CollocatorProvider, Coordinator, CoordinatorProvider, InstanceNotFound}
+import com.socrata.datacoordinator.service.collocation.{CollocatorProvider, CoordinatorProvider, InstanceNotFound}
 import com.socrata.http.server.responses._
 import com.socrata.http.server.{HttpRequest, HttpResponse}
 
@@ -16,9 +18,12 @@ object CollocatedDatasetsResult {
 }
 
 case class CollocationManifestsResource(instanceId: Option[String],
+                                        datasetId: Option[String],
                                         provider: CoordinatorProvider with CollocatorProvider) extends CollocationSodaResource {
 
   override def post = getCollocatedDatasets
+
+  override def delete = dropCollocations
 
   import provider._
 
@@ -39,6 +44,23 @@ case class CollocationManifestsResource(instanceId: Option[String],
             case Left(_) => InternalServerError
           }
       }
+    }
+  }
+
+  private def dropCollocations(req: HttpRequest): HttpResponse = {
+    (instanceId, datasetId.flatMap(DatasetInternalName(_))) match {
+      case (Some(instance), Some(dataset)) =>
+        coordinator.dropCollocationsOnInstance(instance, dataset) match {
+          case None => OK
+          case Some(InstanceNotFound(_)) => instanceNotFound(instance)
+          case Some(_) => InternalServerError
+        }
+      case (None, _) => instanceNotFound("")
+      case (_, None) => errorResponse(
+        BadRequest,
+        CollocationError.INVALID_DATASET_INTERNAL_NAME,
+        "dataset" -> JString(datasetId.getOrElse(""))
+      )
     }
   }
 }

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Router.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Router.scala
@@ -25,7 +25,7 @@ case class Router(parseDatasetId: String => Option[DatasetId],
                   secondaryMoveJobsJobResource: String => SodaResource,
                   datasetSecondaryStatusResource: (Option[String], DatasetId) => SodaResource,
                   secondariesOfDatasetResource: DatasetId => SodaResource,
-                  collocationManifestsResource: Option[String] => SodaResource,
+                  collocationManifestsResource: (Option[String], Option[String]) => SodaResource,
                   versionResource: SodaResource) {
 
   type OptString = Option[String]
@@ -81,8 +81,9 @@ case class Router(parseDatasetId: String => Option[DatasetId],
 
       Route("/secondaries-of-dataset/{DatasetId}", secondariesOfDatasetResource),
 
-      Route("/collocation-manifest", collocationManifestsResource(None)),
-      Route("/collocation-manifest/{OptString}", collocationManifestsResource),
+      Route("/collocation-manifest", collocationManifestsResource(None, None)),
+      Route("/collocation-manifest/{OptString}", collocationManifestsResource(_: Option[String], None)),
+      Route("/collocation-manifest/{OptString}/{OptString}", collocationManifestsResource),
 
       Route("/version", versionResource)
     )

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
@@ -43,7 +43,7 @@ class Service(serviceConfig: ServiceConfig,
               secondaryManifestsMoveJobResource: (String, String) => SecondaryManifestsMoveJobResource,
               secondaryMoveJobsJobResource: String => SecondaryMoveJobsJobResource,
               datasetSecondaryStatusResource: (Option[String], DatasetId) => DatasetSecondaryStatusResource,
-              collocationManifestsResource: Option[String] => CollocationManifestsResource,
+              collocationManifestsResource: (Option[String], Option[String]) => CollocationManifestsResource,
               secondariesOfDatasetResource: DatasetId => SecondariesOfDatasetResource
              ) extends CoordinatorErrorsAndMetrics(formatDatasetId)
 {
@@ -312,7 +312,7 @@ object Service {
             formatDatasetId: DatasetId => String,
             parseDatasetId: String => Option[DatasetId],
             notFoundDatasetResource: (Option[String], (=> HttpResponse) => HttpResponse) => NotFoundDatasetResource,
-            datasetResource: (DatasetId, (=> HttpResponse) => HttpResponse) => DatasetResource,
+            datasetResource: CollocationLock => (String => Option[(String, Int)]) => (DatasetId, (=> HttpResponse) => HttpResponse) => DatasetResource,
             datasetSchemaResource: DatasetId => DatasetSchemaResource,
             datasetSnapshotsResource: DatasetId => DatasetSnapshotsResource,
             datasetSnapshotResource: (DatasetId, Long) => DatasetSnapshotResource,
@@ -326,7 +326,7 @@ object Service {
             secondaryManifestsMoveJobResource: (String => Option[(String, Int)]) => (String, String) => SecondaryManifestsMoveJobResource,
             secondaryMoveJobsJobResource: String => SecondaryMoveJobsJobResource,
             datasetSecondaryStatusResource: (Option[String], DatasetId) => DatasetSecondaryStatusResource,
-            collocationManifestsResource: CollocationLock => (String => Option[(String, Int)]) => Option[String] => CollocationManifestsResource,
+            collocationManifestsResource: CollocationLock => (String => Option[(String, Int)]) => (Option[String], Option[String]) => CollocationManifestsResource,
             secondariesOfDatasetResource: DatasetId => SecondariesOfDatasetResource
            )(collocationLock: CollocationLock, hostAndPort: (String => Option[(String, Int)])): Service = {
     new Service(
@@ -334,7 +334,7 @@ object Service {
       formatDatasetId,
       parseDatasetId,
       notFoundDatasetResource,
-      datasetResource,
+      datasetResource(collocationLock)(hostAndPort),
       datasetSchemaResource,
       datasetSnapshotsResource,
       datasetSnapshotResource,

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
@@ -53,7 +53,7 @@ object CollocationResult {
 
 trait Collocator {
   def collocatedDatasets(datasets: Set[DatasetInternalName]): Either[RequestError, CollocatedDatasetsResult]
-  def dropDataset(dataset: DatasetInternalName): Option[RequestError]
+  def dropDataset(dataset: DatasetInternalName): Option[ErrorResult]
   def explainCollocation(storeGroup: String, request: CollocationRequest): Either[ErrorResult, CollocationResult]
   def executeCollocation(jobId: UUID, storeGroup: String, request: CollocationRequest): (Either[ErrorResult, CollocationResult], Seq[(Move, Boolean)])
   def commitCollocation(request: CollocationRequest): Unit
@@ -115,7 +115,7 @@ class CoordinatedCollocator(collocationGroup: Set[String],
     storesInGroup
   }
 
-  override def dropDataset(dataset: DatasetInternalName): Option[RequestError] = {
+  override def dropDataset(dataset: DatasetInternalName): Option[ErrorResult] = {
     log.info("Dropping dataset {} from collocation manifests", dataset)
     collocationGroup.flatMap { instance =>
       coordinator.dropCollocationsOnInstance(instance, dataset)

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
@@ -53,11 +53,12 @@ object CollocationResult {
 
 trait Collocator {
   def collocatedDatasets(datasets: Set[DatasetInternalName]): Either[RequestError, CollocatedDatasetsResult]
+  def dropDataset(dataset: DatasetInternalName): Option[RequestError]
   def explainCollocation(storeGroup: String, request: CollocationRequest): Either[ErrorResult, CollocationResult]
-  def initiateCollocation(jobId: UUID, storeGroup: String, request: CollocationRequest): (Either[ErrorResult, CollocationResult], Seq[(Move, Boolean)])
-  def saveCollocation(request: CollocationRequest): Unit
-  def beginCollocation(): Unit
-  def commitCollocation(): Unit
+  def executeCollocation(jobId: UUID, storeGroup: String, request: CollocationRequest): (Either[ErrorResult, CollocationResult], Seq[(Move, Boolean)])
+  def commitCollocation(request: CollocationRequest): Unit
+  def lockCollocation(): Unit
+  def unlockCollocation(): Unit
   def rollbackCollocation(jobId: UUID, moves: Seq[(Move, Boolean)]): Option[ErrorResult]
 }
 
@@ -114,6 +115,13 @@ class CoordinatedCollocator(collocationGroup: Set[String],
     storesInGroup
   }
 
+  override def dropDataset(dataset: DatasetInternalName): Option[RequestError] = {
+    log.info("Dropping dataset {} from collocation manifests", dataset)
+    collocationGroup.flatMap { instance =>
+      coordinator.dropCollocationsOnInstance(instance, dataset)
+    }.headOption
+  }
+
   protected def movesFor(group: Set[DatasetInternalName], storesFrom: Set[String], storesTo: Set[String]): Seq[Move] = {
     assert(storesFrom.size == storesTo.size)
 
@@ -124,7 +132,7 @@ class CoordinatedCollocator(collocationGroup: Set[String],
         group.map(Move(_, storeFrom, storeTo, Cost.Unknown)) // TODO
       }
   }
-  
+
   protected def datasetCost(storeGroup: String, dataset: DatasetInternalName, instances: Set[String]): Cost = {
     instances.intersect(secondariesOfDataset(dataset)).flatMap { storeId =>
       // TODO: use Metric.datasetMaxCost here instead
@@ -235,7 +243,7 @@ class CoordinatedCollocator(collocationGroup: Set[String],
     }
   }
 
-  override def initiateCollocation(jobId: UUID,
+  override def executeCollocation(jobId: UUID,
                                   storeGroup: String,
                                   request: CollocationRequest): (Either[ErrorResult, CollocationResult], Seq[(Move, Boolean)]) = {
     log.info("Executing collocation on secondary store group {}", storeGroup)
@@ -286,36 +294,36 @@ class CoordinatedCollocator(collocationGroup: Set[String],
     }
   }
 
-  override def saveCollocation(request: CollocationRequest): Unit = {
+  override def commitCollocation(request: CollocationRequest): Unit = {
     // save the collocation relationships to the database after ensuring all required moves jobs exists
     // this way we only need to roll back jobs for our job id back if something goes wrong
     log.info("Adding collocation relationships to the manifest: {}", request.collocations)
     addCollocations(request.collocations)
   }
 
-  override def beginCollocation(): Unit = {
+  override def lockCollocation(): Unit = {
     try {
-      log.info("Attempting to acquire collocation lock to begin collocation.")
+      log.info("Attempting to acquire collocation lock")
       if (lock.acquire(lockTimeoutMillis)) {
-        log.info("Acquired collocation lock to begin collocation.")
+        log.info("Acquired collocation lock")
       } else {
-        log.warn("Timeout while waiting to acquire collocation lock to begin collocation.")
+        log.warn("Timeout while waiting to acquire collocation lock")
         throw CollocationLockTimeout(lockTimeoutMillis)
       }
     } catch {
       case error: CollocationLockError =>
-        log.error("Unexpected error while acquiring collocation lock for collocation.", error)
+        log.error("Unexpected error while acquiring collocation lock ", error)
         throw error
     }
   }
 
-  override def commitCollocation(): Unit = {
+  override def unlockCollocation(): Unit = {
     try {
-      log.info("Releasing collocation lock to commit collocation.")
+      log.info("Releasing collocation lock")
       lock.release()
     } catch {
       case error: CollocationLockError =>
-        log.error("Unexpected error while releasing collocation lock for collocation.", error)
+        log.error("Unexpected error while releasing collocation lock", error)
         throw error
     }
   }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/CollocationManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/CollocationManifest.scala
@@ -3,4 +3,5 @@ package com.socrata.datacoordinator.secondary
 trait CollocationManifest {
   def collocatedDatasets(datasets: Set[String]): Set[String]
   def addCollocations(collocations: Set[(String, String)]): Unit
+  def dropCollocations(dataset: String): Unit
 }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlCollocationManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlCollocationManifest.scala
@@ -38,4 +38,16 @@ abstract class SqlCollocationManifest(conn: Connection) extends CollocationManif
       }
     }
   }
+
+  override def dropCollocations(dataset: String): Unit = {
+    using(conn.prepareStatement(
+      """DELETE FROM collocation_manifest
+        | WHERE dataset_internal_name_left = ?
+        |    OR dataset_internal_name_right = ?
+      """.stripMargin)) { stmt =>
+      stmt.setString(1, dataset)
+      stmt.setString(2, dataset)
+      stmt.execute()
+    }
+  }
 }


### PR DESCRIPTION
Drop entries from collocation manifests as datasets are deleted.

New route:

 - `DELETE /collocation-manifest/{instance}/{dataset_system_id}`:
   Drops entries for the given dataset from the collocation manifest
   of the given data-coordinator instance.