### PR TITLE
EN-22550: Drop entries from collocation manifests

### DIFF
--- a/coordinator-external/src/main/scala/com/socrata/datacoordinator/external/DataCoordinatorError.scala
+++ b/coordinator-external/src/main/scala/com/socrata/datacoordinator/external/DataCoordinatorError.scala
@@ -68,6 +68,7 @@ object CollocationError {
   val DATASET_NOT_FOUND_IN_STORE = "collocation.secondary.dataset-not-found-in-store"
 
   val INVALID_JOB_ID = "collocation.job.invalid-uuid"
+  val INVALID_DATASET_INTERNAL_NAME = "collocation.dataset.invalid-internal-name"
 }
 
 object SecondaryMetricsError {

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/collocation/CollocationManifestsResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/collocation/CollocationManifestsResource.scala
@@ -1,8 +1,10 @@
 package com.socrata.datacoordinator.resources.collocation
 
+import com.rojoma.json.v3.ast.JString
 import com.rojoma.json.v3.util.{AutomaticJsonCodecBuilder, JsonKeyStrategy, Strategy}
+import com.socrata.datacoordinator.external.CollocationError
 import com.socrata.datacoordinator.id.DatasetInternalName
-import com.socrata.datacoordinator.service.collocation.{CollocatorProvider, Coordinator, CoordinatorProvider, InstanceNotFound}
+import com.socrata.datacoordinator.service.collocation.{CollocatorProvider, CoordinatorProvider, InstanceNotFound}
 import com.socrata.http.server.responses._
 import com.socrata.http.server.{HttpRequest, HttpResponse}
 
@@ -16,9 +18,12 @@ object CollocatedDatasetsResult {
 }
 
 case class CollocationManifestsResource(instanceId: Option[String],
+                                        datasetId: Option[String],
                                         provider: CoordinatorProvider with CollocatorProvider) extends CollocationSodaResource {
 
   override def post = getCollocatedDatasets
+
+  override def delete = dropCollocations
 
   import provider._
 
@@ -39,6 +44,23 @@ case class CollocationManifestsResource(instanceId: Option[String],
             case Left(_) => InternalServerError
           }
       }
+    }
+  }
+
+  private def dropCollocations(req: HttpRequest): HttpResponse = {
+    (instanceId, datasetId.flatMap(DatasetInternalName(_))) match {
+      case (Some(instance), Some(dataset)) =>
+        coordinator.dropCollocationsOnInstance(instance, dataset) match {
+          case None => OK
+          case Some(InstanceNotFound(_)) => instanceNotFound(instance)
+          case Some(_) => InternalServerError
+        }
+      case (None, _) => instanceNotFound("")
+      case (_, None) => errorResponse(
+        BadRequest,
+        CollocationError.INVALID_DATASET_INTERNAL_NAME,
+        "dataset" -> JString(datasetId.getOrElse(""))
+      )
     }
   }
 }

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
@@ -271,6 +271,12 @@ class Main(common: SoQLCommon, serviceConfig: ServiceConfig) {
     }
   }
 
+  def dropCollocations(dataset: DatasetInternalName): Unit = {
+    for (u <- common.universe) yield {
+      u.collocationManifest.dropCollocations(dataset.underlying)
+    }
+  }
+
   def secondaryMetrics(storeId: String, datasetId: Option[DatasetId]): Either[ResourceNotFound, Option[SecondaryMetric]] = {
     val secondaries = serviceConfig.secondary.groups.flatMap(_._2.instances).toSet
     if (secondaries(storeId)) {
@@ -567,9 +573,6 @@ object Main extends DynamicPortMap {
         val notFoundDatasetResource = NotFoundDatasetResource(_: Option[String], common.internalNameFromDatasetId,
           operations.makeReportTemporaryFile, operations.processCreation,
           operations.listDatasets, _: (=> HttpResponse) => HttpResponse, serviceConfig.commandReadLimit)
-        val datasetResource = DatasetResource(_: DatasetId, operations.makeReportTemporaryFile,
-          serviceConfig.commandReadLimit, operations.processMutation, operations.deleteDataset,
-          operations.exporter, _: (=> HttpResponse) => HttpResponse, common.internalNameFromDatasetId)
         val datasetSchemaResource = DatasetSchemaResource(_: DatasetId, getSchema, common.internalNameFromDatasetId)
         val datasetSnapshotsResource = DatasetSnapshotsResource(_: DatasetId, getSnapshots, common.internalNameFromDatasetId)
         val datasetSnapshotResource = DatasetSnapshotResource(_: DatasetId, _: Long, deleteSnapshot, common.internalNameFromDatasetId)
@@ -593,6 +596,7 @@ object Main extends DynamicPortMap {
             hostAndPort,
             new HttpClientHttpClient(executorService), // since executorService is currently unbounded we can share here
             operations.collocatedDatasets,
+            operations.dropCollocations,
             operations.secondariesOfDataset,
             operations.secondaryMetrics,
             operations.secondaryMoveJobsByStoreId,
@@ -624,6 +628,20 @@ object Main extends DynamicPortMap {
           }
         }
 
+        def datasetResource(lock: CollocationLock)(hostAndPort: String => Option[(String, Int)]) = {
+          DatasetResource(
+            _: DatasetId,
+            operations.makeReportTemporaryFile,
+            serviceConfig.commandReadLimit,
+            operations.processMutation,
+            operations.deleteDataset,
+            operations.exporter,
+            collocationProvider(hostAndPort, lock).collocator,
+            _: (=> HttpResponse) => HttpResponse,
+            common.internalNameFromDatasetId
+          )
+        }
+
         def secondaryManifestsCollocateResource(lock: CollocationLock)(hostAndPort: String => Option[(String, Int)]) = {
           SecondaryManifestsCollocateResource(_: String, collocationProvider(hostAndPort, lock))
         }
@@ -649,7 +667,7 @@ object Main extends DynamicPortMap {
         val secondaryMoveJobsJobResource = SecondaryMoveJobsJobResource(_: String, operations.secondaryMoveJobsByStoreId)
 
         def collocationManifestsResource(lock: CollocationLock)(hostAndPort: String => Option[(String, Int)]) = {
-          CollocationManifestsResource(_: Option[String], collocationProvider(hostAndPort, lock))
+          CollocationManifestsResource(_: Option[String], _: Option[String], collocationProvider(hostAndPort, lock))
         }
 
         val datasetSecondaryStatusResource = DatasetSecondaryStatusResource(_: Option[String], _:DatasetId, secondaries,

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Router.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Router.scala
@@ -25,7 +25,7 @@ case class Router(parseDatasetId: String => Option[DatasetId],
                   secondaryMoveJobsJobResource: String => SodaResource,
                   datasetSecondaryStatusResource: (Option[String], DatasetId) => SodaResource,
                   secondariesOfDatasetResource: DatasetId => SodaResource,
-                  collocationManifestsResource: Option[String] => SodaResource,
+                  collocationManifestsResource: (Option[String], Option[String]) => SodaResource,
                   versionResource: SodaResource) {
 
   type OptString = Option[String]
@@ -81,8 +81,9 @@ case class Router(parseDatasetId: String => Option[DatasetId],
 
       Route("/secondaries-of-dataset/{DatasetId}", secondariesOfDatasetResource),
 
-      Route("/collocation-manifest", collocationManifestsResource(None)),
-      Route("/collocation-manifest/{OptString}", collocationManifestsResource),
+      Route("/collocation-manifest", collocationManifestsResource(None, None)),
+      Route("/collocation-manifest/{OptString}", collocationManifestsResource(_: Option[String], None)),
+      Route("/collocation-manifest/{OptString}/{OptString}", collocationManifestsResource),
 
       Route("/version", versionResource)
     )

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
@@ -43,7 +43,7 @@ class Service(serviceConfig: ServiceConfig,
               secondaryManifestsMoveJobResource: (String, String) => SecondaryManifestsMoveJobResource,
               secondaryMoveJobsJobResource: String => SecondaryMoveJobsJobResource,
               datasetSecondaryStatusResource: (Option[String], DatasetId) => DatasetSecondaryStatusResource,
-              collocationManifestsResource: Option[String] => CollocationManifestsResource,
+              collocationManifestsResource: (Option[String], Option[String]) => CollocationManifestsResource,
               secondariesOfDatasetResource: DatasetId => SecondariesOfDatasetResource
              ) extends CoordinatorErrorsAndMetrics(formatDatasetId)
 {
@@ -312,7 +312,7 @@ object Service {
             formatDatasetId: DatasetId => String,
             parseDatasetId: String => Option[DatasetId],
             notFoundDatasetResource: (Option[String], (=> HttpResponse) => HttpResponse) => NotFoundDatasetResource,
-            datasetResource: (DatasetId, (=> HttpResponse) => HttpResponse) => DatasetResource,
+            datasetResource: CollocationLock => (String => Option[(String, Int)]) => (DatasetId, (=> HttpResponse) => HttpResponse) => DatasetResource,
             datasetSchemaResource: DatasetId => DatasetSchemaResource,
             datasetSnapshotsResource: DatasetId => DatasetSnapshotsResource,
             datasetSnapshotResource: (DatasetId, Long) => DatasetSnapshotResource,
@@ -326,7 +326,7 @@ object Service {
             secondaryManifestsMoveJobResource: (String => Option[(String, Int)]) => (String, String) => SecondaryManifestsMoveJobResource,
             secondaryMoveJobsJobResource: String => SecondaryMoveJobsJobResource,
             datasetSecondaryStatusResource: (Option[String], DatasetId) => DatasetSecondaryStatusResource,
-            collocationManifestsResource: CollocationLock => (String => Option[(String, Int)]) => Option[String] => CollocationManifestsResource,
+            collocationManifestsResource: CollocationLock => (String => Option[(String, Int)]) => (Option[String], Option[String]) => CollocationManifestsResource,
             secondariesOfDatasetResource: DatasetId => SecondariesOfDatasetResource
            )(collocationLock: CollocationLock, hostAndPort: (String => Option[(String, Int)])): Service = {
     new Service(
@@ -334,7 +334,7 @@ object Service {
       formatDatasetId,
       parseDatasetId,
       notFoundDatasetResource,
-      datasetResource,
+      datasetResource(collocationLock)(hostAndPort),
       datasetSchemaResource,
       datasetSnapshotsResource,
       datasetSnapshotResource,

--- a/coordinator/src/test/scala/com/socrata/datacoordinator/service/collocation/CoordinatedCollocatorTest.scala
+++ b/coordinator/src/test/scala/com/socrata/datacoordinator/service/collocation/CoordinatedCollocatorTest.scala
@@ -307,7 +307,7 @@ class CoordinatedCollocatorTest extends FunSuite with Matchers with MockFactory 
 
   // tests for explainCollocation(storeGroup: String, request: CollocationRequest): Either[ErrorResult, CollocationResult]
   // and
-  // tests for initiateCollocation(jobId: UUID, storeGroup: String, request: CollocationRequest): (Either[ErrorResult, CollocationResult], Seq[(Move, Boolean)])
+  // tests for executeCollocation(jobId: UUID, storeGroup: String, request: CollocationRequest): (Either[ErrorResult, CollocationResult], Seq[(Move, Boolean)])
 
   def shouldBeApproved(maybeResult: Either[ErrorResult, CollocationResult]): Unit = {
     val result = maybeResult.right.get
@@ -371,13 +371,13 @@ class CoordinatedCollocatorTest extends FunSuite with Matchers with MockFactory 
       }
     }
 
-    test("initiateCollocation " + message) {
+    test("executeCollocation " + message) {
       withMocks(Set(storeGroupA), { coordinator =>
         commonCoordinatorExpectations(coordinator)
         initiateCoordinatorExpectations(coordinator)
       }, commonMetricExpectations) { case (collocator, _) =>
         val jobId = UUID.randomUUID()
-        val (result, moves) = collocator.initiateCollocation(jobId, storeGroupA, request)
+        val (result, moves) = collocator.executeCollocation(jobId, storeGroupA, request)
 
         commonShould(result)
         initiateShould(jobId, result, moves)
@@ -628,68 +628,67 @@ class CoordinatedCollocatorTest extends FunSuite with Matchers with MockFactory 
       result.moves.map(_.storeIdTo).toSet should be (Set(store1A, store3A))
     }
   )
-
-  // def initiateCollocation(jobId: UUID, storeGroup: String, request: CollocationRequest): (Either[ErrorResult, CollocationResult], Seq[(Move, Boolean)])
-  // tests for saveCollocation(request: CollocationRequest): Unit
-  test("saveCollocation for an empty request should save nothing to the manifest") {
+  
+  // tests for commitCollocation(request: CollocationRequest): Unit
+  test("commitCollocation for an empty request should save nothing to the manifest") {
     withMocks(defaultStoreGroups) { (collocator, manifest) =>
-      collocator.saveCollocation(requestEmpty)
+      collocator.commitCollocation(requestEmpty)
 
       manifest.get should be (Set.empty)
     }
   }
 
-  test("saveCollocation for a single pair should save that pair to the manifest") {
+  test("commitCollocation for a single pair should save that pair to the manifest") {
     withMocks(defaultStoreGroups) { (collocator, manifest) =>
-      collocator.saveCollocation(request(Seq((alpha1, bravo1))))
+      collocator.commitCollocation(request(Seq((alpha1, bravo1))))
 
       manifest.get should be (Set((alpha1, bravo1)))
     }
   }
 
-  test("saveCollocation for multiple pairs should save those pairs to the manifest") {
+  test("commitCollocation for multiple pairs should save those pairs to the manifest") {
     withMocks(defaultStoreGroups) { (collocator, manifest) =>
       val collocations = Seq(
         (alpha1, bravo1),
         (bravo1, charlie2),
         (alpha1, charlie2)
       )
-      collocator.saveCollocation(request(collocations))
+      collocator.commitCollocation(request(collocations))
 
       manifest.get should be (collocations.toSet)
     }
   }
 
-  // tests for beginCollocation(): Unit
-  test("beginCollocation should acquire the collocation lock") {
+  // tests for lockCollocation(): Unit
+  test("lockCollocation should acquire the collocation lock") {
     withMocks(defaultStoreGroups, expectNoMockCoordinatorCalls, expectNoMockMetricCalls, { lock =>
       (lock.acquire _).expects(10000L).once.returns(true)
 
     }) { (collocator, _) =>
-      collocator.beginCollocation()
+      collocator.lockCollocation()
     }
   }
 
-  test("beginCollocation should throw a CollocationLockTimeout exception if it cannot acquire the collocation lock") {
+  test("lockCollocation should throw a CollocationLockTimeout exception if it cannot acquire the collocation lock") {
     withMocks(defaultStoreGroups, expectNoMockCoordinatorCalls, expectNoMockMetricCalls, { lock =>
       (lock.acquire _).expects(10000L).once.returns(false)
 
     }) { (collocator, _) =>
       val result = intercept[CollocationLockTimeout] {
-        collocator.beginCollocation()
+        collocator.lockCollocation()
       }
 
       result.millis should be (10000L)
     }
   }
 
-  // tests for commitCollocation(): Unit
-  test("commitCollocation should release the collocation lock") {
+  // tests for unlockCollocation(): Unit
+  test("unlockCollocation should release the collocation lock") {
     withMocks(defaultStoreGroups, expectNoMockCoordinatorCalls, expectNoMockMetricCalls, { lock =>
       (lock.release _).expects().once
 
     }) { (collocator, _) =>
-      collocator.commitCollocation()
+      collocator.unlockCollocation()
     }
   }
 

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/CollocationManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/CollocationManifest.scala
@@ -3,4 +3,5 @@ package com.socrata.datacoordinator.secondary
 trait CollocationManifest {
   def collocatedDatasets(datasets: Set[String]): Set[String]
   def addCollocations(collocations: Set[(String, String)]): Unit
+  def dropCollocations(dataset: String): Unit
 }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlCollocationManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlCollocationManifest.scala
@@ -38,4 +38,16 @@ abstract class SqlCollocationManifest(conn: Connection) extends CollocationManif
       }
     }
   }
+
+  override def dropCollocations(dataset: String): Unit = {
+    using(conn.prepareStatement(
+      """DELETE FROM collocation_manifest
+        | WHERE dataset_internal_name_left = ?
+        |    OR dataset_internal_name_right = ?
+      """.stripMargin)) { stmt =>
+      stmt.setString(1, dataset)
+      stmt.setString(2, dataset)
+      stmt.execute()
+    }
+  }
 }


### PR DESCRIPTION
Drop entries from collocation manifests as datasets are deleted.

New route:

 - `DELETE /collocation-manifest/{instance}/{dataset_system_id}`:
   Drops entries for the given dataset from the collocation manifest
   of the given data-coordinator instance.