### PR TITLE
EN-17026: Collocation API will not overfill stores

### DIFF
--- a/configs/sample.conf
+++ b/configs/sample.conf
@@ -35,7 +35,7 @@ com.socrata.coordinator.common = {
         numReplicas = 1
         instances {
           spandex {
-            storeCapacityMB = 1000
+            storeCapacityMB = 0
             acceptingNewDatasets = true
           }
         }

--- a/configs/sample.conf
+++ b/configs/sample.conf
@@ -24,15 +24,30 @@ com.socrata.coordinator.common = {
     groups {
       pg {
         numReplicas = 1
-        instances = [pg]
+        instances = {
+          pg {
+            storeCapacityMB = 1000
+            acceptingNewDatasets = true
+          }
+        }
       }
       spandex {
         numReplicas = 1
-        instances = [spandex]
+        instances {
+          spandex {
+            storeCapacityMB = 1000
+            acceptingNewDatasets = true
+          }
+        }
       }
       geocoding {
         numReplicas = 1
-        instances = [geocoding]
+        instances {
+          geocoding {
+            storeCapacityMB = 0 # no actual store
+            acceptingNewDatasets = true
+          }
+        }
       }
     }
     instances {

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
@@ -452,7 +452,9 @@ object Main extends DynamicPortMap {
     val secondaries: Set[String] = serviceConfig.secondary.groups.flatMap(_._2.instances.keySet).toSet
     // TODO: remove this
     val secondariesNotAcceptingNewDatasets: Set[String] =
-      serviceConfig.secondary.groups.flatMap(_._2.instances.filter(!_._2.acceptingNewDatasets).keySet).toSet
+      serviceConfig.secondary.groups.flatMap { case (_, group) =>
+        group.instances.filter { case (_, instance) => !instance.acceptingNewDatasets }.keySet
+      }.toSet
 
     val collocationGroup: Set[String] = serviceConfig.collocation.group
     if (collocationGroup.nonEmpty && !collocationGroup.contains(serviceConfig.instance)) {

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
@@ -242,7 +242,7 @@ class CoordinatedCollocator(collocationGroup: Set[String],
                   totalMoves.groupBy(_.storeIdTo).flatMap { case (storeId, moves) =>
                     val bytesToMove = Move.totalCost(moves).totalSizeBytes
                     val storeTotalBytes = storeMetricsMap(storeId).totalSizeBytes
-                    val storeCapacityBytes = groupConfig.instances(storeId).storeCapacityMB * 1000 * 1000
+                    val storeCapacityBytes = groupConfig.instances(storeId).storeCapacityMB * 1024 * 1024
 
                     if (storeTotalBytes + bytesToMove > storeCapacityBytes)
                       Some(Rejected(s"the moves exceed the capacity of store $storeId"))

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
@@ -252,7 +252,7 @@ class CoordinatedCollocator(collocationGroup: Set[String],
 
               totalStatus match {
                 case Rejected(reason) => log.info("Rejecting collocation request because {}", reason)
-                case Approved => log.info("Approving collocation request")
+                case Approved => log.info("Approving collocation request for collocations: {}", request.collocations)
                 case _ => throw new Exception("Unexpected collocation status in explain")
               }
 

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
@@ -250,6 +250,12 @@ class CoordinatedCollocator(collocationGroup: Set[String],
                   }.headOption.getOrElse(Approved)
                 }
 
+              totalStatus match {
+                case Rejected(reason) => log.info("Rejecting collocation request because {}", reason)
+                case Approved => log.info("Approving collocation request")
+                case _ => throw new Exception("Unexpected collocation status in explain")
+              }
+
               Right(CollocationResult(
                 id = None,
                 status = totalStatus,

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Metric.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Metric.scala
@@ -1,10 +1,12 @@
 package com.socrata.datacoordinator.service.collocation
 
 import com.socrata.datacoordinator.id.DatasetInternalName
+import com.socrata.datacoordinator.secondary.SecondaryMetric
 
 trait Metric {
   val collocationGroup: Set[String]
   def datasetMaxCost(storeGroup: String, dataset: DatasetInternalName): Either[ErrorResult, Cost]
+  def storeMetrics(storeId: String): Either[ErrorResult, SecondaryMetric]
 }
 
 trait MetricProvider {
@@ -18,7 +20,7 @@ case class CoordinatedMetric(collocationGroup: Set[String],
       val currentInstances = coordinator.secondariesOfDataset(dataset).fold(throw _, _.getOrElse(throw DatasetNotFound(dataset)).secondaries.keySet)
 
       val costs = for {
-        storeId <- currentInstances.intersect(coordinator.secondaryGroupConfigs(storeGroup).instances)
+        storeId <- currentInstances.intersect(coordinator.secondaryGroupConfigs(storeGroup).instances.keySet)
         metric <- coordinator.secondaryMetrics(storeId, dataset).fold(throw _, identity)
       } yield {
         Cost(moves = 1, totalSizeBytes = metric.totalSizeBytes)
@@ -27,6 +29,18 @@ case class CoordinatedMetric(collocationGroup: Set[String],
       val maxCost = costs.reduceOption(costOrdering.max).getOrElse(Cost.Unknown)
 
       Right(maxCost)
+    } catch {
+      case error: ErrorResult => Left(error)
+    }
+  }
+
+  override def storeMetrics(storeId: String): Either[ErrorResult, SecondaryMetric] = {
+    try {
+      val totalSizeBytes = collocationGroup.toSeq.map { instance =>
+        coordinator.secondaryMetrics(storeId, instance).fold(throw _, _.totalSizeBytes)
+      }.sum
+
+      Right(SecondaryMetric(totalSizeBytes))
     } catch {
       case error: ErrorResult => Left(error)
     }

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/secondary/stores/SecondaryStoreSelector.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/secondary/stores/SecondaryStoreSelector.scala
@@ -73,7 +73,7 @@ object SecondaryStoreSelector {
             storeMetrics: Map[String, SecondaryMetric])(implicit costOrdering: Ordering[Cost]): SecondaryStoreSelector = {
     val storesFreeSpaceMap = groupConfig.instances.map { case (storeId, storeConfig) =>
       val freeSpaceBytes = if (storeConfig.acceptingNewDatasets)
-        storeConfig.storeCapacityMB * 1000L * 1000L - storeMetrics(storeId).totalSizeBytes
+        storeConfig.storeCapacityMB * 1024L * 1024L - storeMetrics(storeId).totalSizeBytes
       else 0L
 
       (storeId, freeSpaceBytes)

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/secondary/stores/SecondaryStoreSelector.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/secondary/stores/SecondaryStoreSelector.scala
@@ -1,5 +1,6 @@
 package com.socrata.datacoordinator.service.collocation.secondary.stores
 
+import com.socrata.datacoordinator.secondary.SecondaryMetric
 import com.socrata.datacoordinator.secondary.config.SecondaryGroupConfig
 import com.socrata.datacoordinator.service.collocation.Cost
 
@@ -9,16 +10,20 @@ case class NotEnoughInstancesInSecondaryGroup(name: String, count: Int)
   extends Exception(s"Unable to find $count available instances in secondary store group $name.")
 
 class SecondaryStoreSelector(groupName: String,
-                             allStores: Set[String],
-                             unavailableStores: Set[String],
+                             storesFreeSpaceMap: Map[String, Long],
                              replicationFactor: Int)(implicit costOrdering: Ordering[Cost]) {
 
   def maxCostKey[T](costMap: Map[T, Cost]): Option[T] =
     if (costMap.nonEmpty) Some(costMap.maxBy(_._2)._1) // max by Cost and return key
     else None
 
-  def invalidDestinationStore[T](store: String, storeMap: Map[T, Set[String]]): Boolean =
-    unavailableStores(store) && !storeMap.forall(_._2.contains(store))
+  private def unavailableStores(cost: Cost): Set[String] =
+    storesFreeSpaceMap.filter(cost.totalSizeBytes > _._2).keySet
+
+  def invalidDestinationStore[T](store: String, storeMap: Map[T, Set[String]], costMap: Map[T, Cost]): Boolean = {
+    val cost = costMap.filterKeys(!storeMap(_).contains(store)).values.fold(Cost.Zero)(_ + _)
+    unavailableStores(cost)(store) && !storeMap.forall(_._2.contains(store))
+  }
 
   def destinationStores[T](storeMap: Map[T, Set[String]], costMap: Map[T, Cost]): Set[String] = {
     @tailrec
@@ -27,7 +32,7 @@ class SecondaryStoreSelector(groupName: String,
         val currentKey = maxCostKey(toExplore).get
         val currentStores = storeMap(currentKey)
 
-        val possibleStores = currentStores.filterNot { s => seen(s) || invalidDestinationStore(s, storeMap) }
+        val possibleStores = currentStores.filterNot { s => seen(s) || invalidDestinationStore(s, storeMap, costMap) }
         randomStore(possibleStores) match {
           case Some(selected) =>
             val nowSeen = seen ++ (currentStores -- possibleStores) + selected
@@ -37,7 +42,9 @@ class SecondaryStoreSelector(groupName: String,
             store(toExplore.filterNot(_._1 == currentKey), nowSeen)
         }
       } else {
-        randomStore(allStores -- (unavailableStores ++ seen)) match {
+        val allStores = storesFreeSpaceMap.keySet
+        val totalCost = costMap.values.fold(Cost.Zero)(_ + _)
+        randomStore(allStores -- (unavailableStores(totalCost) ++ seen)) match {
           case Some(selected) => (selected, seen + selected)
           case None =>  throw NotEnoughInstancesInSecondaryGroup(groupName, replicationFactor)
         }
@@ -62,11 +69,15 @@ class SecondaryStoreSelector(groupName: String,
 
 object SecondaryStoreSelector {
   def apply(groupName: String,
-            groupConfig: SecondaryGroupConfig)(implicit costOrdering: Ordering[Cost]): SecondaryStoreSelector =
-    new SecondaryStoreSelector(
-      groupName = groupName,
-      allStores = groupConfig.instances,
-      unavailableStores = groupConfig.instancesNotAcceptingNewDatasets.getOrElse(Set.empty),
-      replicationFactor = groupConfig.numReplicas
-    )
+            groupConfig: SecondaryGroupConfig,
+            storeMetrics: Map[String, SecondaryMetric])(implicit costOrdering: Ordering[Cost]): SecondaryStoreSelector = {
+    val storesFreeSpaceMap = groupConfig.instances.map { case (storeId, storeConfig) =>
+      val freeSpaceBytes = if (storeConfig.acceptingNewDatasets)
+        storeConfig.storeCapacityMB * 1000L * 1000L - storeMetrics(storeId).totalSizeBytes
+      else 0L
+
+      (storeId, freeSpaceBytes)
+    }
+    new SecondaryStoreSelector(groupName, storesFreeSpaceMap, groupConfig.numReplicas)
+  }
 }

--- a/coordinator/src/test/scala/com/socrata/datacoordinator/service/MainTest.scala
+++ b/coordinator/src/test/scala/com/socrata/datacoordinator/service/MainTest.scala
@@ -1,11 +1,13 @@
 package com.socrata.datacoordinator.service
 
-import com.socrata.datacoordinator.secondary.config.SecondaryGroupConfig
+import com.socrata.datacoordinator.secondary.config.{SecondaryGroupConfig, StoreConfig}
 import com.socrata.datacoordinator.id.DatasetId
-import org.scalatest.{MustMatchers, FunSuite}
+import org.scalatest.{FunSuite, MustMatchers}
 
 class MainTest extends FunSuite with MustMatchers {
-  private val sg1 = SecondaryGroupConfig(2, Set("pg1", "pg2", "pg3"), None)
+  private val sg1 = SecondaryGroupConfig(2, Map("pg1" -> StoreConfig(1000, true), "pg2" -> StoreConfig(1000, true), "pg3" -> StoreConfig(1000, true)))
+  private val sg2 = SecondaryGroupConfig(2, Map("pg1" -> StoreConfig(1000, true), "pg2" -> StoreConfig(1000, false), "pg3" -> StoreConfig(1000, true)))
+  private val sg3 = SecondaryGroupConfig(2, Map("pg1" -> StoreConfig(1000, true), "pg2" -> StoreConfig(1000, false), "pg3" -> StoreConfig(1000, false)))
   private val ds = new DatasetId(1234)
 
   test("do nothing if already have sufficient") {
@@ -17,25 +19,25 @@ class MainTest extends FunSuite with MustMatchers {
     // ensure it has enough from the specific  group, not just any group
     val newSecondaries = Main.secondariesToAdd(sg1, Set("pg1", "pg4", "pgx"), ds, "g1")
     newSecondaries must have size 1
-    newSecondaries.intersect(sg1.instances) must have size 1
+    newSecondaries.intersect(sg1.instances.keySet) must have size 1
   }
 
   test("add if none in group") {
     val newSecondaries = Main.secondariesToAdd(sg1, Set(), ds, "g1")
     newSecondaries must have size 2
-    newSecondaries.intersect(sg1.instances) must have size 2
+    newSecondaries.intersect(sg1.instances.keySet) must have size 2
   }
 
   test("add but not to instance not accepting new datasets") {
-    val newSecondaries = Main.secondariesToAdd(sg1.copy(instancesNotAcceptingNewDatasets = Some(Set("pg2"))), Set.empty, ds, "g1")
+    val newSecondaries = Main.secondariesToAdd(sg2, Set.empty, ds, "g1")
     newSecondaries must have size 2
-    newSecondaries.intersect(sg1.instances) must have size 2
+    newSecondaries.intersect(sg2.instances.keySet) must have size 2
     newSecondaries.intersect(Set("pg2")) must have size 0
   }
 
   test("add but not to instance not accepting new datasets fails when there are not enough available instances") {
     val result = intercept[Exception] {
-      Main.secondariesToAdd(sg1.copy(instancesNotAcceptingNewDatasets = Some(Set("pg2", "pg3"))), Set.empty, ds, "g1")
+      Main.secondariesToAdd(sg3, Set.empty, ds, "g1")
     }
     result.getMessage must be ("Can't find 2 servers in secondary group g1 to publish to")
   }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/config/SecondaryConfig.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/config/SecondaryConfig.scala
@@ -8,10 +8,11 @@ import net.ceedubs.ficus.FicusConfig._
 // reflection-based horror that doesn't even provide full paths to
 // errors.
 
+case class StoreConfig(storeCapacityMB: Long, acceptingNewDatasets: Boolean)
+
 case class SecondaryGroupConfig(
      numReplicas: Int,
-     instances: Set[String],
-     instancesNotAcceptingNewDatasets: Option[Set[String]]
+     instances: Map[String, StoreConfig]
  )
 
 case class SecondaryInstanceConfig(


### PR DESCRIPTION
Collocation API will not overfill secondary stores.

Reworks secondary store config to include values for the
store capacity. This capacity should be the rough capacity
the store has for row data and indices of datasets, it should
not include capacity needed to metadata.