### PR TITLE
EN-24804: Fix collocation manifest recursive query

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlCollocationManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlCollocationManifest.scala
@@ -11,9 +11,9 @@ abstract class SqlCollocationManifest(conn: Connection) extends CollocationManif
   override def collocatedDatasets(datasets: Set[String]): Set[String] = {
     def getNeighbors(dataset: String): Set[String] = {
       using(conn.prepareStatement(
-        """SELECT dataset_internal_name_left FROM related_data_sets WHERE dataset_internal_name_right = ?
+        """SELECT dataset_internal_name_left FROM collocation_manifest WHERE dataset_internal_name_right = ?
           |UNION
-          |SELECT dataset_internal_name_right FROM related_data_sets WHERE dataset_internal_name_left = ?""".stripMargin))
+          |SELECT dataset_internal_name_right FROM collocation_manifest WHERE dataset_internal_name_left = ?""".stripMargin))
       { stmt =>
         stmt.setString(1, dataset)
         stmt.setString(2, dataset)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlCollocationManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlCollocationManifest.scala
@@ -5,38 +5,43 @@ import java.sql.Connection
 import com.rojoma.simplearm.util.using
 import com.socrata.datacoordinator.secondary.CollocationManifest
 
+import scala.collection.mutable
+
 abstract class SqlCollocationManifest(conn: Connection) extends CollocationManifest {
-  override def collocatedDatasets(datasets: Set[String]) = {
-    using(conn.prepareStatement(
-      """WITH RECURSIVE related_data_sets(dataset_internal_name_left, dataset_internal_name_right, system_id, path, cycle) AS (
-        |    SELECT dataset_internal_name_left, dataset_internal_name_right, system_id, ARRAY[system_id], false
-        |      FROM collocation_manifest WHERE dataset_internal_name_left = ANY(?) OR dataset_internal_name_right = ANY(?)
-        |    UNION ALL
-        |    SELECT src.dataset_internal_name_left, src.dataset_internal_name_right, src.system_id, path || src.system_id, src.system_id = ANY(path)
-        |      FROM collocation_manifest src, related_data_sets rn
-        |      WHERE (
-        |          src.dataset_internal_name_left=rn.dataset_internal_name_right OR
-        |          src.dataset_internal_name_right=rn.dataset_internal_name_left OR
-        |          src.dataset_internal_name_left=rn.dataset_internal_name_left OR
-        |          src.dataset_internal_name_right=rn.dataset_internal_name_right
-        |        )
-        |        AND NOT cycle
-        |      )
-        |SELECT dataset_internal_name_left FROM related_data_sets
-        |UNION
-        |SELECT dataset_internal_name_right FROM related_data_sets""".stripMargin))
-    { stmt =>
-      val datasetsArray =  conn.createArrayOf("varchar", datasets.toArray)
-      stmt.setArray(1, datasetsArray)
-      stmt.setArray(2, datasetsArray)
-      using(stmt.executeQuery()) { rs =>
-        val result = Set.newBuilder[String]
-        while (rs.next()) {
-          result += rs.getString("dataset_internal_name_left")
+  override def collocatedDatasets(datasets: Set[String]): Set[String] = {
+    def getNeighbors(dataset: String): Set[String] = {
+      using(conn.prepareStatement(
+        """SELECT dataset_internal_name_left FROM related_data_sets WHERE dataset_internal_name_right = ?
+          |UNION
+          |SELECT dataset_internal_name_right FROM related_data_sets WHERE dataset_internal_name_left = ?""".stripMargin))
+      { stmt =>
+        stmt.setString(1, dataset)
+        stmt.setString(2, dataset)
+        using(stmt.executeQuery()) { rs =>
+          val result = Set.newBuilder[String]
+          while (rs.next()) {
+            result += rs.getString("dataset_internal_name_left")
+          }
+          result.result()
         }
-        result.result()
       }
     }
+
+    val toVisit = mutable.Queue.empty[String]
+    val visited = mutable.Set.empty[String]
+
+    datasets.foreach(toVisit.enqueue(_))
+
+    while (toVisit.nonEmpty) {
+      val current = toVisit.dequeue()
+      visited.add(current)
+
+      getNeighbors(current).foreach { neighbor =>
+        if (!visited.contains(neighbor) && !toVisit.contains(neighbor)) toVisit.enqueue(neighbor)
+      }
+    }
+
+    visited.toSet
   }
 
   override def dropCollocations(dataset: String): Unit = {


### PR DESCRIPTION
Because of the UNION ALL in the recursive query on the collocation
manifest causes the rows at each depth to increase factorially in
number (a problem for datasets with a large branching factor), the
query is far too slow -- and worse -- creates very large temp tables.

Replace the query with a breadth first search of the collocation
manifest implemented in scala.