### PR TITLE
EN-32060 Pass row and row previous image to handlers.

### DIFF
--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
@@ -123,7 +123,7 @@ class FeedbackContext[CT,CV](user: String,
     val toCompute = rows.iterator.zipWithIndex.flatMap { case (row, index) =>
       val rcis =
         perColumnDataAndDependentColumns.flatMap { case (columnData, dependentColumns) =>
-          // Don't compute if there has been to change to the dependent columns which include source columns + target column
+          // Don't compute if there has been no change to the dependent columns which include source columns + target column.
           // New value of either target or source will have the same existing if update does not contain the field.
           // There should be no change either they contain the same value or are not passed in
           if (noChange(row, dependentColumns))

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
@@ -116,17 +116,17 @@ class FeedbackContext[CT,CV](user: String,
                              rows: IndexedSeq[Row[CV]],
                              targetColumns: Set[UserColumnId]): Either[ComputationFailure, Map[Int, Map[UserColumnId, CV]]] = {
     val perDatasetData = computationHandler.setupDataset(cookie)
-    val perColumnDataAndTargetColId = cookie.strategyMap.toSeq.collect {
+    val perColumnDataAndDependentColumns = cookie.strategyMap.toSeq.collect {
       case (targetCol, strat) if targetColumns.contains(targetCol) & computationHandler.matchesStrategyType(strat.strategyType) =>
-        (computationHandler.setupColumn(perDatasetData, strat, targetCol), targetCol)
+        (computationHandler.setupColumn(perDatasetData, strat, targetCol), strat.sourceColumnIds :+ targetCol)
     }
     val toCompute = rows.iterator.zipWithIndex.flatMap { case (row, index) =>
       val rcis =
-        perColumnDataAndTargetColId.flatMap { case (columnData, targetColId) =>
-          // don't compute if there has been to change to the source columns
+        perColumnDataAndDependentColumns.flatMap { case (columnData, dependentColumns) =>
+          // Don't compute if there has been to change to the dependent columns which include source columns + target column
           // New value of either target or source will have the same existing if update does not contain the field.
           // There should be no change either they contain the same value or are not passed in
-          if (noChange(row, columnData.strategy.sourceColumnIds :+ targetColId))
+          if (noChange(row, dependentColumns))
             None
           else
             Some(computationHandler.setupCell(columnData, row))

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
@@ -116,18 +116,22 @@ class FeedbackContext[CT,CV](user: String,
                              rows: IndexedSeq[Row[CV]],
                              targetColumns: Set[UserColumnId]): Either[ComputationFailure, Map[Int, Map[UserColumnId, CV]]] = {
     val perDatasetData = computationHandler.setupDataset(cookie)
-    val perColumnData = cookie.strategyMap.toSeq.collect {
+    val perColumnDataTargetColMap = cookie.strategyMap.toSeq.collect {
       case (targetCol, strat) if targetColumns.contains(targetCol) & computationHandler.matchesStrategyType(strat.strategyType) =>
-        computationHandler.setupColumn(perDatasetData, strat, targetCol)
-    }
+        (computationHandler.setupColumn(perDatasetData, strat, targetCol) -> targetCol)
+    }.toMap
+    val perColumnData = perColumnDataTargetColMap.keys.toSeq
     val toCompute = rows.iterator.zipWithIndex.flatMap { case (row, index) =>
       val rcis =
         perColumnData.flatMap { columnData =>
           // don't compute if there has been to change to the source columns
-          if (noChange(row, columnData.strategy.sourceColumnIds))
+          val targetColId = perColumnDataTargetColMap(columnData)
+          // New value of either target or source will have the same existing if update does not contain the field.
+          // There should be no change either they contain the same value or are not passed in
+          if (noChange(row, columnData.strategy.sourceColumnIds :+ targetColId))
             None
           else
-            Some(computationHandler.setupCell(columnData, row.data))
+            Some(computationHandler.setupCell(columnData, row))
         }
       if (rcis.isEmpty) Iterator.empty
       else Iterator.single(index -> rcis)

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondary.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondary.scala
@@ -35,7 +35,7 @@ trait ComputationHandler[CT,CV] {
   /**
    * @return The PerCellData for performing the computation of the target column
    */
-  def setupCell(column: PerColumnData, row: secondary.Row[CV]): PerCellData
+  def setupCell(column: PerColumnData, row: Row[CV]): PerCellData
 
   type ComputationResult[RowHandle] = Either[ComputationFailure, Map[RowHandle, Map[UserColumnId, CV]]]
 

--- a/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/AdditionSecondary.scala
+++ b/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/AdditionSecondary.scala
@@ -25,8 +25,8 @@ class AdditionHandler extends ComputationHandler[SoQLType, SoQLValue] {
     new AdditionColumnInfo(strategy.sourceColumnIds.map(cookie.columnIdMap(_)), strategy, targetColId)
   }
 
-  override def setupCell(colInfo: AdditionColumnInfo, row: secondary.Row[SoQLValue]): AdditionRowInfo = {
-    AdditionRowInfo(row, colInfo.sources, colInfo.targetColId)
+  override def setupCell(colInfo: AdditionColumnInfo, row: Row[SoQLValue]): AdditionRowInfo = {
+    AdditionRowInfo(row.data, colInfo.sources, colInfo.targetColId)
   }
 
   override def compute[RowHandle](sources: Map[RowHandle, Seq[AdditionRowInfo]]): ComputationResult[RowHandle] = {


### PR DESCRIPTION
Include target column (in addition to source columns) in comparing row change/no change.

These two changes allow handlers to have more flexibility in determining when to recompute.