### PR TITLE
EN-32392 align truth instance naming convention between prod/dev to a…

### DIFF
--- a/configs/sample.conf
+++ b/configs/sample.conf
@@ -17,9 +17,9 @@ com.socrata.coordinator.common = {
   # data coordinator.  It doesn't have any semantic meaning but it is used
   # to form the internal names of datasets and to advertise the server
   # in zookeeper.
-  instance = primus
+  instance = alpha
 
-  collocation.group = [primus]
+  collocation.group = [alpha]
 
   secondary {
     defaultGroups = [pg]

--- a/secondarylib/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
+++ b/secondarylib/src/test/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherTest.scala
@@ -42,10 +42,10 @@ class SecondaryWatcherTest extends FunSuite with MustMatchers with MockFactory {
     new LoggedTimingReport(log) with StackedTimingReport with MetricsTimingReport with TaggableTimingReport,
     allowDdlOnPublishedCopies = false, // don't care,
     Duration.fromNanos(1L), // don't care
-    "primus-test",
+    "alpha-test",
     new java.io.File(System.getProperty("java.io.tmpdir")).getAbsoluteFile,
     Duration.fromNanos(1L), // don't care
-    Duration.fromNanos(1L), // don't care 
+    Duration.fromNanos(1L), // don't care
     //Duration.fromNanos(1L),
     NullCache
   )


### PR DESCRIPTION
…lpha (previously primus in dev)