### PR TITLE
Allow gating updates by expected dataset version

### DIFF
--- a/coordinator-external/src/main/scala/com/socrata/datacoordinator/external/DataCoordinatorError.scala
+++ b/coordinator-external/src/main/scala/com/socrata/datacoordinator/external/DataCoordinatorError.scala
@@ -46,6 +46,7 @@ object ParameterRequestError {
 
 object ScriptHeaderRequestError{
   val MISMATCHED_SCHEMA = "req.script.header.mismatched-schema"
+  val MISMATCHED_DATA_VERSION = "req.script.header.mismatched-data-version"
   val MISSING = "req.script.header.missing"
 }
 

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/DatasetResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/DatasetResource.scala
@@ -199,7 +199,7 @@ case class DatasetResource(datasetId: DatasetId,
             upstreamPrecondition, ifModifiedSince, sorted, rowId) {
             case Left(newSchema) =>
               mismatchedSchema(ExportRequestError.MISMATCHED_SCHEMA, datasetId, newSchema)(resp)
-            case Right((etag, lastModified, schema, rowIdCol, locale, approxRowCount, rows)) =>
+            case Right((etag, dataVersion, lastModified, schema, rowIdCol, locale, approxRowCount, rows)) =>
               resp.setContentType("application/json")
               resp.setCharacterEncoding("utf-8")
               resp.setDateHeader("Last-Modified", lastModified.getMillis)
@@ -208,6 +208,8 @@ case class DatasetResource(datasetId: DatasetId,
               val jsonWriter = new CompactJsonWriter(out)
               out.write("[{\"approximate_row_count\":")
               out.write(JNumber(approxRowCount).toString)
+              out.write("\n ,\"data_version\":")
+              out.write(JNumber(dataVersion).toString)
               out.write("\n ,\"last_modified\":")
               jsonWriter.write(JString(ISODateTimeFormat.dateTime.print(lastModified)))
               out.write("\n ,\"locale\":")
@@ -245,6 +247,6 @@ case class DatasetResource(datasetId: DatasetId,
 }
 
 object DatasetResource{
-  type datasetContentsFunc = Either[Schema, (EntityTag, DateTime, Seq[SchemaField], Option[UserColumnId], String, Long,
+  type datasetContentsFunc = Either[Schema, (EntityTag, Long, DateTime, Seq[SchemaField], Option[UserColumnId], String, Long,
     Iterator[Array[JValue]])] => Unit
 }

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/CoordinatorErrorsAndMetrics.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/CoordinatorErrorsAndMetrics.scala
@@ -76,6 +76,10 @@ class CoordinatorErrorsAndMetrics(formatDatasetId: DatasetId => String) extends 
     mismatchedSchema(code, formatDatasetId(datasetId), schema, data:_*)
   }
 
+  def mismatchedDataVersion(code: String, datasetId: DatasetId, version: Long, data: (String, JValue)*): HttpResponse = {
+    mismatchedDataVersion(code, formatDatasetId(datasetId), version, data:_*)
+  }
+
   def noSuchColumnLabel(code: String, datasetId: DatasetId, data: (String, JValue)*): HttpResponse = {
     datasetErrorResponse(BadRequest, code,
       "dataset" -> JString(formatDatasetId(datasetId)),
@@ -87,6 +91,13 @@ class CoordinatorErrorsAndMetrics(formatDatasetId: DatasetId => String) extends 
     datasetErrorResponse(Conflict, code,
       "dataset" -> JString(name),
       "schema" -> jsonifySchema(schema),
+      "data" -> JObject(data.toMap))
+  }
+
+  def mismatchedDataVersion(code: String, name: String, version: Long, data: (String, JValue)*): HttpResponse = {
+    datasetErrorResponse(Conflict, code,
+      "dataset" -> JString(name),
+      "version" -> JNumber(version),
       "data" -> JObject(data.toMap))
   }
 

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
@@ -339,7 +339,7 @@ class Main(common: SoQLCommon, serviceConfig: ServiceConfig) {
     ifModifiedSince: Option[DateTime],
     sorted: Boolean,
     rowId: Option[String]
-   )(f: Either[Schema, (EntityTag, DateTime, Seq[SchemaField], Option[UserColumnId],
+   )(f: Either[Schema, (EntityTag, Long, DateTime, Seq[SchemaField], Option[UserColumnId],
      String,
      Long,
      Iterator[Array[JValue]])] => Unit): Exporter.Result[Unit] = {
@@ -369,6 +369,7 @@ class Main(common: SoQLCommon, serviceConfig: ServiceConfig) {
               }
               f(Right((
                 entityTag,
+                copyCtx.datasetInfo.latestDataVersion,
                 copyCtx.copyInfo.lastModified,
                 orderedSchema,
                 pkColName,

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
@@ -129,6 +129,9 @@ class Service(serviceConfig: ServiceConfig,
             case Mutator.MismatchedSchemaHash(name, schema) =>
               mismatchedSchema(ScriptHeaderRequestError.MISMATCHED_SCHEMA, name, schema,
                 "commandIndex" -> JNumber(em.index))
+            case Mutator.MismatchedDataVersion(name, version) =>
+              mismatchedDataVersion(ScriptHeaderRequestError.MISMATCHED_DATA_VERSION, name, version,
+                "commandIndex" -> JNumber(em.index))
             case Mutator.NoSuchColumnLabel(name, label) =>
               noSuchColumnLabel(ScriptCommandRequestError.UNKNOWN_LABEL, name,
                 "commandIndex" -> JNumber(em.index),

--- a/coordinatorlib/src/it/scala/com/socrata/datacoordinator/truth/metadata/sql/PostgresDatasetMapWriterTest.scala
+++ b/coordinatorlib/src/it/scala/com/socrata/datacoordinator/truth/metadata/sql/PostgresDatasetMapWriterTest.scala
@@ -54,6 +54,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
     def userTypeForType(typ: TypeName): TypeName = typ
   }
   val ZeroID = 0L
+  val ZeroVersion = 0L
 
   val resourcName = Some("_abcd-1234")
 
@@ -102,7 +103,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can create a table") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
 
       vi.datasetInfo.tableBase must be ("t" + vi.datasetInfo.systemId.underlying)
@@ -116,7 +117,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can add a column to a table") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       val ci = tables.addColumn(vi, c("col1"), fn("co1"), t("typ"), "colbase")
 
@@ -132,7 +133,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can make a column a primary key") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       val ci = tables.addColumn(vi, c("col1"), fn("co1"), t("typ"), "colbase")
 
@@ -144,7 +145,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can add a second column to a table") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       val ci1 = tables.addColumn(vi, c("col1"), fn("co1"), t("typ"), "colbase")
       val ci2 = tables.addColumn(vi, c("col2"), fn("co2"), t("typ2"), "colbase2")
@@ -161,7 +162,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Cannot have multiple primary keys") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       val ci1 = tables.addColumn(vi, c("col1"), fn("co1"), t("typ"), "colbase")
       val ci2 = tables.addColumn(vi, c("col2"), fn("co2"), t("typ2"), "colbase2")
@@ -175,7 +176,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can clear a user primary key and re-seat it") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       val ci1 = tables.addColumn(vi, c("col1"), fn("co1"), t("typ"), "colbase")
       val ci2 = tables.addColumn(vi, c("col2"), fn("co2"), t("typ2"), "colbase2")
@@ -190,7 +191,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Cannot add the same column twice") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       tables.addColumn(vi, c("col1"), fn("co1"), t("typ"), "colbase")
 
@@ -200,7 +201,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can publish the initial working copy") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
       val vi2 = tables.publish(vi1)
       vi2 must equal ((vi1.copy(lifecycleStage = LifecycleStage.Published)(null), None))
@@ -212,7 +213,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can drop a column") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       val c1 = tables.addColumn(vi, c("col1"), fn("co1"), t("typ1"), "pcol1")
       val c2 = tables.addColumn(vi, c("col2"), fn("co2"), t("typ2"), "pcol2")
@@ -225,7 +226,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can make a working copy") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.publish(tables.create("en_US", resourcName))
       val ci1 = tables.addColumn(vi1._1, c("col1"), fn("co1"), t("typ"), "colbase")
       val ci2 = tables.addColumn(vi1._1, c("col2"), fn("co2"), t("typ2"), "colbase2")
@@ -243,7 +244,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Cannot drop a published version") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
       val vi2 = tables.publish(vi1)
 
@@ -254,7 +255,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Cannot drop the initial version when it's still unpublished") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       vi.lifecycleStage must be (LifecycleStage.Unpublished)
       an [CannotDropInitialWorkingCopyException] must be thrownBy { tables.dropCopy(vi) }
@@ -263,7 +264,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can drop a non-initial unpublished version") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
       val vi2 = tables.publish(vi1)
       val Right(CopyPair(_, vi3)) = tables.ensureUnpublishedCopy(vi2._1.datasetInfo)
@@ -277,7 +278,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Column IDs are allocated into the first gap if one exists") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       tables.addColumnWithId(new ColumnId(0), vi, c("col0"), fn("co0"), t("typ0"), "t")
       tables.addColumnWithId(new ColumnId(2), vi, c("col2"), fn("co2"), t("typ2"), "t")
@@ -287,7 +288,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Column IDs are allocated as 0 if it doesn't exist") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       tables.addColumnWithId(new ColumnId(1), vi, c("col1"), fn("co1"), t("typ1"), "t")
       tables.addColumnWithId(new ColumnId(2), vi, c("col2"), fn("co2"), t("typ2"), "t")
@@ -297,7 +298,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Column IDs are allocated at the end if there are no gaps") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi = tables.create("en_US", resourcName)
       tables.addColumnWithId(new ColumnId(0), vi, c("col0"), fn("co0"), t("typ0"), "t")
       tables.addColumnWithId(new ColumnId(1), vi, c("col1"), fn("co1"), t("typ1"), "t")
@@ -307,7 +308,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Adding a column to a table does not use IDs from this table or the previous version") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi0 = tables.create("en_US", resourcName)
       val ci0 = tables.addColumn(vi0, c("col0"), fn("co0"), t("typ0"), "base0")
       val ci1 = tables.addColumn(vi0, c("col1"), fn("co1"), t("typ1"), "base1")
@@ -322,7 +323,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can delete a table entirely") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
       tables.addColumn(vi1, c("col1"), fn("co1"), t("typ1"), "pcol1")
       tables.addColumn(vi1, c("col2"), fn("co2"), t("typ2"), "pcol2")
@@ -352,7 +353,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can create and update rollup metadata") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
       def rollupCount = count(conn, "rollup_map", s"name = '${rollupName.underlying}' AND copy_system_id=${vi1.systemId.underlying}")
 
@@ -373,7 +374,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can lookup rollup metadata") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
 
       tables.rollup(vi1, rollupName) must be (None)
@@ -392,7 +393,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can drop rollup metadata") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
 
       tables.rollup(vi1, rollupName) must be (None)
@@ -405,7 +406,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Can drop multiple rollup metadata") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
 
       tables.rollup(vi1, rollupName) must be (None)
@@ -418,7 +419,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
 
   test("Dropping dataset drops all rollup metadata") {
     withDb() { conn =>
-      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID)
+      val tables = new PostgresDatasetMapWriter(conn, noopTypeNamespace, NoopTimingReport, noopKeyGen, ZeroID, ZeroVersion)
       val vi1 = tables.create("en_US", resourcName)
 
       tables.publish(vi1)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/SoQLCommon.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/SoQLCommon.scala
@@ -96,6 +96,7 @@ class SoQLCommon(dataSource: DataSource,
   def versionObfuscationContextFor(cryptProvider: CryptProvider) = new SoQLVersion.StringRep(cryptProvider)
   def generateObfuscationKey(): Array[Byte] = CryptProvider.generateKey()
   val initialCounterValue = 0L
+  val initialLatestDataVersion = 0L
 
   val sqlRepFor = SoQLRep.sqlRep _
   def jsonReps(datasetInfo: DatasetInfo): (SoQLType => JsonColumnRep[SoQLType, SoQLValue]) = {
@@ -218,6 +219,7 @@ class SoQLCommon(dataSource: DataSource,
     val executor: ExecutorService = common.executorService
     val obfuscationKeyGenerator: () => Array[Byte] = common.generateObfuscationKey _
     val initialCounterValue: Long = common.initialCounterValue
+    val initialLatestDataVersion: Long = common.initialLatestDataVersion
     val tablespace: (String) => Option[String] = common.tableSpace
     val copyInProvider: (Connection, String, OutputStream => Unit) => Long = common.copyInProvider
     val timingReport = common.timingReport

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetInfo.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetInfo.scala
@@ -45,13 +45,14 @@ object UnanchoredDatasetInfo extends ((DatasetId, Long, String, Array[Byte], Opt
   * or [[com.socrata.datacoordinator.truth.metadata.DatasetMapWriter]].
   * @param tag Guard against a non-map accidentially instantiating this.
   */
-case class DatasetInfo(systemId: DatasetId, nextCounterValue: Long, localeName: String, obfuscationKey: Array[Byte], resourceName: Option[String])(implicit tag: com.socrata.datacoordinator.truth.metadata.`-impl`.Tag) extends DatasetInfoLike {
+case class DatasetInfo(systemId: DatasetId, nextCounterValue: Long, val latestDataVersion: Long, localeName: String, obfuscationKey: Array[Byte], resourceName: Option[String])(implicit tag: com.socrata.datacoordinator.truth.metadata.`-impl`.Tag) extends DatasetInfoLike {
   def unanchored: UnanchoredDatasetInfo = UnanchoredDatasetInfo(systemId, nextCounterValue, localeName, obfuscationKey, resourceName)
 
   override def equals(o: Any) = o match {
     case that: DatasetInfo =>
       this.systemId == that.systemId &&
         this.nextCounterValue == that.nextCounterValue &&
+        this.latestDataVersion == that.latestDataVersion &&
         this.localeName == that.localeName &&
         java.util.Arrays.equals(this.obfuscationKey, that.obfuscationKey) && // thanks, java
         this.resourceName == that.resourceName

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
@@ -91,6 +91,7 @@ trait BackupDatasetMap[CT] extends DatasetMapWriter[CT] with `-impl`.BaseDataset
     *       newly created dataset will have NO copies attached. */
   def unsafeCreateDataset(systemId: DatasetId,
                           nextCounterValue: Long,
+                          latestDataVersion: Long,
                           localeName: String,
                           obfuscationKey: Array[Byte],
                           resourceName: Option[String]): DatasetInfo
@@ -107,6 +108,7 @@ trait BackupDatasetMap[CT] extends DatasetMapWriter[CT] with `-impl`.BaseDataset
     *       for resyncing only.  The resulting dataset object will have NO copies. */
   def unsafeReloadDataset(datasetInfo: DatasetInfo,
                           nextCounterValue: Long,
+                          latestDataVersion: Long,
                           localeName: String,
                           obfuscationKey: Array[Byte],
                           resourceName: Option[String]): DatasetInfo

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/PostgresUniverse.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/PostgresUniverse.scala
@@ -41,6 +41,7 @@ trait PostgresCommonSupport[CT, CV] {
 
   val obfuscationKeyGenerator: () => Array[Byte]
   val initialCounterValue: Long
+  val initialLatestDataVersion: Long
   val tablespace: String => Option[String]
   val copyInProvider: (Connection, String, OutputStream => Unit) => Long
   val timingReport: TransferrableContextTimingReport
@@ -173,7 +174,7 @@ class PostgresUniverse[ColumnType, ColumnValue](conn: Connection,
     new PostgresDatasetMapReader(conn, typeContext.typeNamespace, timingReport)
 
   lazy val datasetMapWriter: DatasetMapWriter[CT] =
-    new PostgresDatasetMapWriter(conn, typeContext.typeNamespace, timingReport, obfuscationKeyGenerator, initialCounterValue)
+    new PostgresDatasetMapWriter(conn, typeContext.typeNamespace, timingReport, obfuscationKeyGenerator, initialCounterValue, initialLatestDataVersion)
 
   lazy val secondaryStoresConfig =
     new SqlSecondaryStoresConfig(conn, timingReport)


### PR DESCRIPTION
We already send back the new version on every mutation in a header, so
it is possible to do multiple writes while guaranteeing that no one
has touched the dataset in between.

This also presents the data version on exports, so it will be possible
to do an atomic read-modify-update cycle with dataset-level granularity.

This is all in support of doing incremental updates to datasets
externally.