### PR TITLE
Fix a bunch of warnings I missed in the 2.12 upgrade

### DIFF
--- a/coordinatorlib/src/it/scala/com/socrata/datacoordinator/truth/metadata/sql/PostgresDatasetMapWriterTest.scala
+++ b/coordinatorlib/src/it/scala/com/socrata/datacoordinator/truth/metadata/sql/PostgresDatasetMapWriterTest.scala
@@ -43,7 +43,7 @@ class PostgresDatasetMapWriterTest extends FunSuite with MustMatchers with Befor
   def t(s: String) = TypeName(s)
   def fn(s: String) = Some(ColumnName(s))
 
-  def noopKeyGen() = new Array[Byte](0)
+  val noopKeyGen = () => new Array[Byte](0)
   val noopTypeNamespace = new TypeNamespace[TypeName] {
     def nameForType(typ: TypeName): String = typ.name
 


### PR DESCRIPTION
They're in it:test which isn't compiled unless you ask it to be.