### PR TITLE
Undo classloader strategy

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,6 @@ ThisBuild / resolvers += "socrata maven" at "https://repo.socrata.com/artifactor
 
 ThisBuild / scalacOptions ++= Seq("-deprecation", "-feature")
 
-ThisBuild / classLoaderLayeringStrategy in Test := ClassLoaderLayeringStrategy.ScalaLibrary
-
 val coordinatorExternal = (project in file("coordinator-external")).
   configs(IntegrationTest).
   settings(Defaults.itSettings)


### PR DESCRIPTION
It was to reduce the metaspace used, but we just increased the amount
we'll permit instead of making per-project changes.

Hopefully this PR builds!