### PR TITLE
Consolidate multiple row-update-only data versions into one big data …

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
@@ -219,6 +219,7 @@ class PlaybackToSecondary[CT, CV](u: PlaybackToSecondary.SuperUniverse[CT, CV],
     // A series of events is consolidatable if it is an update which only
     // changes row data, which is to say if it has the form:
     //    RowsChangedPreview
+    //    zero or one Truncated
     //    zero or more RowDataUpdated
     //    LastModifiedChanged
     def consolidatable(it: BufferedIterator[Delogger.LogEventCompanion]): Boolean = {

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
@@ -283,6 +283,9 @@ class PlaybackToSecondary[CT, CV](u: PlaybackToSecondary.SuperUniverse[CT, CV],
               if(!events.hasNext || events.next().companion != Delogger.Truncated) {
                 throw ResyncSecondaryException("RowsChangedPreview said the dataset was to be truncated, but there was no Truncated event!")
               }
+              if(mostRecentLastModified.isDefined) {
+                throw ResyncSecondaryException("Dataset was truncated but it wasn't the first batch we were looking at!")
+              }
             }
 
             def hasNext: Boolean = {

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/Secondary.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/Secondary.scala
@@ -28,7 +28,7 @@ trait Secondary[CT, CV] {
     * already has this dataVersion.
     * @return a new cookie to store in the secondary map
     */
-  def version(datasetInfo: DatasetInfo, dataVersion: Long, cookie: Cookie, events: Iterator[Event[CT, CV]]): Cookie
+  def version(datasetInfo: DatasetInfo, initialDataVersion: Long, finalDataVersion: Long, cookie: Cookie, events: Iterator[Event[CT, CV]]): Cookie
 
   /**
    * Resyncs a copy of a dataset as part of the resync path.

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/Delogger.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/Delogger.scala
@@ -22,6 +22,7 @@ class UnknownEvent(version: Long, val event: String, msg: String) extends Corrup
 trait Delogger[CV] extends Closeable {
   @throws(classOf[MissingVersion])
   def delog(version: Long): CloseableIterator[Delogger.LogEvent[CV]]
+  def delogOnlyTypes(version: Long): CloseableIterator[Delogger.LogEventCompanion]
   def findPublishEvent(fromVersion: Long, toVersion: Long): Option[Long]
   def lastWorkingCopyCreatedVersion: Option[Long]
   def lastWorkingCopyDroppedOrPublishedVersion: Option[Long]

--- a/dummy-secondary/src/main/scala/com/socrata/dummysecondary/DummySecondary.scala
+++ b/dummy-secondary/src/main/scala/com/socrata/dummysecondary/DummySecondary.scala
@@ -45,10 +45,10 @@ class DummySecondary(config: Config) extends Secondary[Any, Any] {
     * already has this dataVersion.
     * @return a new cookie to store in the secondary map
     */
-  def version(datasetInfo: DatasetInfo, dataVersion: Long, cookie: Secondary.Cookie,
+  def version(datasetInfo: DatasetInfo, initialDataVersion: Long, finalDataVersion: Long, cookie: Secondary.Cookie,
               events: Iterator[Event[Any, Any]]): Secondary.Cookie = {
     println("Got a new version of " + datasetInfo.internalName)
-    println("Version " + dataVersion)
+    println("Version range " + initialDataVersion + "-" + finalDataVersion)
     println("Current cookie: " + cookie)
     StdIn.readLine("Skip or read or resync? ") match {
       case "skip" | "s" =>

--- a/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondaryTest.scala
+++ b/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondaryTest.scala
@@ -94,7 +94,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
     "called with no cookie" should {
       withMockDC("throw a ResyncSecondaryException") { case (secondary, cookie) =>
         val caught = intercept[ResyncSecondaryException] {
-          secondary.version(datasetInfo, 10, cookie, Iterator.empty)
+          secondary.version(datasetInfo, 10, 10, cookie, Iterator.empty)
         }
         caught.reason should be("No cookie value for dataset test")
       }
@@ -102,37 +102,42 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
     "called with an invalid cookie" should {
       withMockDC("throw a ResyncSecondaryException") { case (secondary, _) =>
         var caught = intercept[ResyncSecondaryException] {
-          secondary.version(datasetInfo, 10, Some("not a valid cookie"), Iterator.empty)
+          secondary.version(datasetInfo, 10, 10, Some("not a valid cookie"), Iterator.empty)
         }
         caught.reason should be("No cookie value for dataset test")
 
         caught = intercept[ResyncSecondaryException] {
-          secondary.version(datasetInfo, 10, Some("{\"not_a\":\"valid cookie\"}"), Iterator.empty)
+          secondary.version(datasetInfo, 10, 10, Some("{\"not_a\":\"valid cookie\"}"), Iterator.empty)
         }
         caught.reason should be("No cookie value for dataset test")
       }
     }
     "called for the current version" should {
       withMockDC("do nothing", TestCookie.v10) { case (secondary, cookie) =>
-        secondary.version(datasetInfo, 10, cookie, Iterator.empty) should be(cookie)
+        secondary.version(datasetInfo, 10, 10, cookie, Iterator.empty) should be(cookie)
       }
     }
     "called for a previous version" should {
       withMockDC("do nothing", TestCookie.v10) { case (secondary, cookie) =>
-        secondary.version(datasetInfo, 8, cookie, Iterator.empty) should be(cookie)
+        secondary.version(datasetInfo, 8, 8, cookie, Iterator.empty) should be(cookie)
       }
     }
     "called for a version past the next" should {
       withMockDC("throw a ResyncSecondaryException", TestCookie.v10) { case (secondary, cookie) =>
         val caught = intercept[ResyncSecondaryException] {
-          secondary.version(datasetInfo, 12, cookie, Iterator.empty)
+          secondary.version(datasetInfo, 12, 12, cookie, Iterator.empty)
         }
         caught.reason should be("Unexpected data version 12")
       }
     }
     "called for version 1 with no cookie" should {
       withMockDC("succeed and return the expected cookie", TestCookie.v1) { case (secondary, cookie) =>
-        secondary.version(datasetInfo, 1, None, TestEvent.v1Events) should be(cookie)
+        secondary.version(datasetInfo, 1, 1, None, TestEvent.v1Events) should be(cookie)
+      }
+    }
+    "called for a range starting at version 1 with no cookie" should {
+      withMockDC("succeed and return the expected cookie", Some(FeedbackCookie(TestCookie.v1Schema.copy(dataVersion = DataVersion(5)), None))) { case (secondary, cookie) =>
+        secondary.version(datasetInfo, 1, 5, None, TestEvent.v1Events) should be(cookie)
       }
     }
 
@@ -143,7 +148,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.systemPKEmpty)
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events), TestCookie.v3)
+        shouldBe(secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events), TestCookie.v3)
       }
     }
     "called for a version with a new computed column with unexpected error with DC client" should {
@@ -153,7 +158,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
         val caught = intercept[Exception] {
-          secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events)
+          secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events)
         }
         caught.getMessage should be("Unexpected error in data-coordinator client: test")
       }
@@ -165,7 +170,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
         val caught = intercept[ReplayLaterSecondaryException] {
-          secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events)
+          secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events)
         }
         caught.reason should be(FailedToDiscoverDataCoordinator.english)
         val expectedCookie = FeedbackCookie.encode(TestCookie.v2.get.copy(errorMessage = Some(FailedToDiscoverDataCoordinator.english)))
@@ -179,7 +184,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
         val caught = intercept[ReplayLaterSecondaryException] {
-          secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events)
+          secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events)
         }
         caught.reason should be(DataCoordinatorBusy.english)
         val expectedCookie = FeedbackCookie.encode(TestCookie.v2.get.copy(errorMessage = Some(DataCoordinatorBusy.english)))
@@ -192,7 +197,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.exportRows _).expects(columns(num1, num2), TestCookie.v3Schema, *).once.returning(TestRows.num1DoesNotExist)
         (mockDC.postMutationScript _).expects(*, *).never
       }) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events), TestCookie.v3almost5)
+        shouldBe(secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events), TestCookie.v3almost5)
       }
     }
 
@@ -205,7 +210,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.success)
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(1), TestCookie.v3Schema).once.returning(TestScripts.success)
       }) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events), TestCookie.v3)
+        shouldBe(secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events), TestCookie.v3)
       }
     }
     "called for a version with a new computed column target column deleted before post" should {
@@ -216,7 +221,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.success)
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(1), TestCookie.v3Schema).once.returning(TestScripts.sum12DoesNotExist)
       }) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events), TestCookie.v3almost4)
+        shouldBe(secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events), TestCookie.v3almost4)
       }
     }
     "called and receives an unexpected error when posting a mutation script" should {
@@ -227,7 +232,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.unexpectedError)
       }) { case (secondary, cookie) =>
         val caught = intercept[ReplayLaterSecondaryException] {
-          secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events)
+          secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events)
         }
         caught.reason should be("test")
         // for this the data-coordinator retries should be decremented
@@ -243,7 +248,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.failedToDiscoverDC)
       }) { case (secondary, cookie) =>
         val caught = intercept[ReplayLaterSecondaryException] {
-          secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events)
+          secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events)
         }
         caught.reason should be(FailedToDiscoverDataCoordinator.english)
         val expectedCookie = FeedbackCookie.encode(TestCookie.v2.get.copy(errorMessage = Some(FailedToDiscoverDataCoordinator.english)))
@@ -258,7 +263,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.dataCoordinatorBusy)
       }) { case (secondary, cookie) =>
         val caught = intercept[ReplayLaterSecondaryException] {
-          secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events)
+          secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events)
         }
         caught.reason should be(DataCoordinatorBusy.english)
         val expectedCookie = FeedbackCookie.encode(TestCookie.v2.get.copy(errorMessage = Some(DataCoordinatorBusy.english)))
@@ -272,24 +277,24 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         // computed values should be posted in batches
         (mockDC.postMutationScript _).expects(TestScripts.sum12Scripts(0), TestCookie.v3Schema).once.returning(TestScripts.doesNotExist)
       }) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 3, cookie, TestEvent.v3Events), TestCookie.v3)
+        shouldBe(secondary.version(datasetInfo, 3, 3, cookie, TestEvent.v3Events), TestCookie.v3)
       }
     }
 
     // tests around publication / working copy creation / dropping
     "called for a version containing publish event" should {
       withMockDC("do no work and return the expected cookie", TestCookie.v6) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 7, cookie, TestEvent.v7Events), TestCookie.v7)
+        shouldBe(secondary.version(datasetInfo, 7, 7, cookie, TestEvent.v7Events), TestCookie.v7)
       }
     }
     "called for a version containing a working copy created event" should {
       withMockDC("do no work and return the expected cookie", TestCookie.v7) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 8, cookie, TestEvent.v8Events), TestCookie.v8)
+        shouldBe(secondary.version(datasetInfo, 8, 8, cookie, TestEvent.v8Events), TestCookie.v8)
       }
     }
     "called for a version containing a working copy dropped event" should {
       withMockDC("do no work and return the expected cookie", TestCookie.v8) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 9, cookie, TestEvent.v9Events), TestCookie.v9)
+        shouldBe(secondary.version(datasetInfo, 9, 9, cookie, TestEvent.v9Events), TestCookie.v9)
       }
     }
 
@@ -303,12 +308,12 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         (mockDC.postMutationScript _).expects(TestScripts.sum23ScriptsV11BatchesOf3(1), TestCookie.v10Schema).once.returning(TestScripts.success)
         (mockDC.postMutationScript _).expects(TestScripts.sum23ScriptsV11BatchesOf3(2), TestCookie.v10Schema).once.returning(TestScripts.success)
       }) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 10, cookie, TestEvent.v10Events), TestCookie.v10)
+        shouldBe(secondary.version(datasetInfo, 10, 10, cookie, TestEvent.v10Events), TestCookie.v10)
       }
     }
     "called for a version containing its own updates to a target computed column" should {
       withMockDC("do no work and return the expected cookie", TestCookie.v10) { case (secondary, cookie) =>
-        shouldBe(secondary.version(datasetInfo, 11, cookie, TestEvent.v11Events), TestCookie.v11)
+        shouldBe(secondary.version(datasetInfo, 11, 11, cookie, TestEvent.v11Events), TestCookie.v11)
       }
     }
   }

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -77,6 +77,7 @@ class SecondaryWatcher[CT, CV](universe: => Managed[SecondaryWatcher.UniverseTyp
         val startingMillis = System.currentTimeMillis()
         try {
           playbackToSecondary(secondary, job)
+          manifest(u).updateRetryInfo(job.storeId, job.datasetId, 0, 0) // done with the job, reset the retry counter
           log.info("<< Sync done for {} into {}", job.datasetId, secondary.storeId)
           completeSecondaryMoveJobs(u, job)
           // Essentially, this simulates unclaimDataset in a finally block.  That is, make sure we clean up whether


### PR DESCRIPTION
…version

In particular you can get a ton of such versions when the feedback
secondaries discover a big change.  This has the potential to make things
MUCH faster on large updates to large datasets even, because it can mean
the feedback secondary has half a hope of triggering the "make an indexless
copy" logic.