### PR TITLE
Handle ancient timestamps better

### DIFF
--- a/coordinatorlib/src/main/java/com/socrata/datacoordinator/common/soql/sqlreps/FixedTimestampHelper.java
+++ b/coordinatorlib/src/main/java/com/socrata/datacoordinator/common/soql/sqlreps/FixedTimestampHelper.java
@@ -1,0 +1,10 @@
+package com.socrata.datacoordinator.common.soql.sqlreps;
+
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+
+class FixedTimestampHelper {
+    public static Instant parse(String s) {
+        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(s, Instant::from);
+    }
+}


### PR DESCRIPTION
This makes me sad, because we're now sending timestamps around as
strings, but java.sql.Timestamp doesn't deal with pre-Gregorian
dates very well.  But at least it ensures we'll read out the same
values we wrote in...