### PR TITLE
Get timestamps as strings, take 2

### DIFF
--- a/coordinatorlib/src/main/java/com/socrata/datacoordinator/common/soql/sqlreps/FixedTimestampHelper.java
+++ b/coordinatorlib/src/main/java/com/socrata/datacoordinator/common/soql/sqlreps/FixedTimestampHelper.java
@@ -1,10 +1,28 @@
 package com.socrata.datacoordinator.common.soql.sqlreps;
 
-import java.time.Instant;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
+import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
-class FixedTimestampHelper {
-    public static Instant parse(String s) {
-        return DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(s, Instant::from);
+public class FixedTimestampHelper {
+    // Postgresql will hand dates to us formatted like
+    //   YYYY-MM-DD HH:MM:SS[.ssss...]±HH[:MM[:SS]][ BC]
+    // This regex pulls those bits out and then
+    // we'll turn them into an Instant.
+    private static final Pattern PATTERN = Pattern.compile("^([0-9]{4}-[0-9]{2}-[0-9]{2}) ([0-9]{2}:[0-9]{2}:[0-9]{2}(?:.[0-9]+)?)([+-][0-9]{2}(?::[0-9]{2}(?::[0-9]{2})?)?)( BC)?$");
+
+    public static final OffsetDateTime parse(String s) {
+        Matcher m = PATTERN.matcher(s);
+        if(!m.matches()) throw new IllegalArgumentException("Malformed timestamp");
+
+        String date = m.group(1);
+        String time = m.group(2);
+        String offset = m.group(3);
+        boolean bc = m.group(4) != null;
+
+        return LocalDateTime.of(LocalDate.parse((bc ? "-" : "") + date),
+                                LocalTime.parse(time)).
+            atOffset(ZoneOffset.of(offset));
     }
 }

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/soql/sqlreps/FixedTimestampRep.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/soql/sqlreps/FixedTimestampRep.scala
@@ -19,11 +19,6 @@ class FixedTimestampRep(val base: String) extends RepUtils with SqlPKableColumnR
 
   val SIZE_GUESSTIMATE = 30
 
-  override def selectList =
-    // This, sadly, appears to be the best way to get postgresql to
-    // produce an ISO8601 timestamp...
-    s"(to_json($base)#>>'{}')"
-
   override val templateForInsert = placeholder
 
   override val templateForUpdate = s"$base = $placeholder"
@@ -92,7 +87,7 @@ class FixedTimestampRep(val base: String) extends RepUtils with SqlPKableColumnR
   def fromResultSet(rs: ResultSet, start: Int): SoQLValue = {
     val ts = rs.getString(start)
     if(ts == null) SoQLNull
-    else SoQLFixedTimestamp(new DateTime(FixedTimestampHelper.parse(ts).toEpochMilli))
+    else SoQLFixedTimestamp(new DateTime(FixedTimestampHelper.parse(ts).toInstant.toEpochMilli))
   }
 }
 


### PR DESCRIPTION
soql-postgres-adapter didn't like the previous one, where the select
list turned the timestamp into an ISO string.  Instead, we'll understand
Postgres's format.