### PR TITLE
Refactor DataSourceFromConfig

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/DataSourceFromConfig.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/DataSourceFromConfig.scala
@@ -3,7 +3,7 @@ package com.socrata.datacoordinator.common
 import com.typesafe.config.Config
 import javax.sql.DataSource
 import java.sql.Connection
-import java.io.OutputStream
+import java.io.{OutputStream, Closeable}
 import org.postgresql.ds.PGSimpleDataSource
 import com.socrata.datacoordinator.truth.universe.sql.{PostgresCopyIn, C3P0WrappedPostgresCopyIn}
 import com.socrata.thirdparty.typesafeconfig.{C3P0Propertizer, ConfigClass}
@@ -25,33 +25,62 @@ class DataSourceConfig(config: Config, root: String) extends ConfigClass(config,
 }
 
 object DataSourceFromConfig {
-  case class DSInfo(dataSource: DataSource, copyIn: (Connection, String, OutputStream => Unit) => Long)
+  trait DSInfo {
+    val dataSource: DataSource
+    val copyIn: (Connection, String, OutputStream => Unit) => Long
+  }
+
+  private def pgDataSource(config: DataSourceConfig): PGSimpleDataSource = {
+    val dataSource = new PGSimpleDataSource
+    dataSource.setServerName(config.host)
+    dataSource.setPortNumber(config.port)
+    dataSource.setDatabaseName(config.database)
+    dataSource.setUser(config.username)
+    dataSource.setPassword(config.password)
+    dataSource.setApplicationName(config.applicationName)
+    dataSource.setTcpKeepAlive(config.tcpKeepAlive)
+    // for these optional configs, we should fall back to the driver's default, if no value is specified
+    config.loginTimeout.foreach(t => dataSource.setLoginTimeout(t.toSeconds.toInt))
+    config.connectTimeout.foreach(t => dataSource.setConnectTimeout(t.toSeconds.toInt))
+    config.cancelSignalTimeout.foreach(t => dataSource.setCancelSignalTimeout(t.toSeconds.toInt))
+    dataSource
+  }
+
+  def unmanaged(config: DataSourceConfig): DSInfo with Closeable = {
+    config.poolOptions match {
+      case Some(poolOptions) =>
+        new DSInfo with Closeable {
+          override val copyIn = C3P0WrappedPostgresCopyIn
+
+          override val dataSource =
+            DataSources.pooledDataSource(
+              pgDataSource(config),
+              null,
+              C3P0Propertizer("", poolOptions)
+            )
+
+          override def close() {
+            DataSources.destroy(dataSource)
+          }
+        }
+      case None => {
+        new DSInfo with Closeable {
+          override val copyIn = PostgresCopyIn
+          override val dataSource = pgDataSource(config)
+          override def close() {}
+        }
+      }
+    }
+  }
+
   def apply(config: DataSourceConfig): Managed[DSInfo] =
     new Managed[DSInfo] {
       def run[A](f: DSInfo => A): A = {
-        val dataSource = new PGSimpleDataSource
-        dataSource.setServerName(config.host)
-        dataSource.setPortNumber(config.port)
-        dataSource.setDatabaseName(config.database)
-        dataSource.setUser(config.username)
-        dataSource.setPassword(config.password)
-        dataSource.setApplicationName(config.applicationName)
-        dataSource.setTcpKeepAlive(config.tcpKeepAlive)
-        // for these optional configs, we should fall back to the driver's default, if no value is specified
-        config.loginTimeout.foreach(t => dataSource.setLoginTimeout(t.toSeconds.toInt))
-        config.connectTimeout.foreach(t => dataSource.setConnectTimeout(t.toSeconds.toInt))
-        config.cancelSignalTimeout.foreach(t => dataSource.setCancelSignalTimeout(t.toSeconds.toInt))
-        config.poolOptions match {
-          case Some(poolOptions) =>
-            val overrideProps = C3P0Propertizer("", poolOptions)
-            val pooled = DataSources.pooledDataSource(dataSource, null, overrideProps)
-            try {
-              f(DSInfo(pooled, C3P0WrappedPostgresCopyIn))
-            } finally {
-              DataSources.destroy(pooled)
-            }
-          case None =>
-            f(DSInfo(dataSource, PostgresCopyIn))
+        val dsInfo = unmanaged(config)
+        try {
+          f(dsInfo)
+        } finally {
+          dsInfo.close()
         }
       }
     }


### PR DESCRIPTION
* it is now possible to get an unmanaged DsInfo
* the managed one is implemented in terms of the unmanaged one
* this is so that this logic doesn't need to be duplicated over in
   pg-secondary
* which is currently is except for the tcp keep alive bit