### PR TITLE
Fix OOM when deleting a large number of rows out of a wide dataset

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/Sqlizer.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/Sqlizer.scala
@@ -14,8 +14,12 @@ trait ReadDataSqlizer[CT, CV] {
 
   def dataTableName: String
 
-  // convenience method; like calling findRowsSubset with all column IDs in the dataset.
   def findRows(conn: Connection, bySystemId: Boolean, ids: Iterator[CV]): CloseableIterator[Seq[InspectedRow[CV]]]
+  // When finding rows, it will be performed (and returned) in chunks
+  // of this size (note that if you ask for rows that don't exist or
+  // provide duplicate IDs, the produced chunks may be smaller than
+  // requested)
+  val findRowsBlockSize: Int
 }
 
 /** Generates SQL for execution. */


### PR DESCRIPTION
Before, deletes were scaled essentially by the size of the delete key.
They would be batched to a threshold and then sent to the worker
thread for processing.  However, the rows for that batch would then be
read out of the database (to populate the log with) and _that_ could
be large.  So now, when we're processing a batch of deletes, process
it in bounded-size chunks (specifically, the size that findRows will
naturally chunk in) to prevent this.

This isn't _completely_ ideal (in partciular, if a dataset has VERY
large rows we'll still end up with a large amount of memory in use
post-chunking) but that's a general problem when reading out of the
database as it's fundamentally row-chunk-based at the JDBC api level.