### PR TITLE
Fix ensuring dataset-in-same-secondaries when there's multiple colloc groups

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Main.scala
@@ -506,7 +506,7 @@ class Main(common: SoQLCommon, serviceConfig: ServiceConfig) {
     val preferredSecondaries = secondariesLike match {
       case Some(datasetInternalName) =>
         val candidateSecondariesInGroup = secondaryGroup.instances.filter(_._2.acceptingNewDatasets).keySet
-        val secs = collocationProvider.collocator.secondariesOfDataset(datasetInternalName)
+        val secs = collocationProvider.collocator.secondariesOfDataset(datasetInternalName).filter(secondaryGroup.instances.keySet)
         secs.find(!candidateSecondariesInGroup.contains(_)) match {
           case Some(sec) =>
             throw new Exception(s"Secondary ${sec} like ${datasetInternalName.underlying} is no longer accepting datasets" )


### PR DESCRIPTION
Before, we were finding the secondaries of dataset and then finding
any that were not (in our target collocation group and accepting new
datasets) but if the _DEFAULT_ meta-group has multiple groups in it,
then this will always fail when it asks "is this secondary from group B
in the set of datasets in group A that are still accepting datasets?"

So, when doing this check, limit ourselves to the secondaries that are
actually in the group under consideration.