### PR TITLE
Allow ourselves to introspect query plans for specific upsert operations

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/resources/DebugResource.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/resources/DebugResource.scala
@@ -1,0 +1,49 @@
+package com.socrata.datacoordinator.resources
+
+import java.io.InputStreamReader
+import java.nio.charset.StandardCharsets
+
+import com.socrata.datacoordinator.service.ServiceUtil._
+import com.socrata.http.server._
+import com.socrata.http.server.responses._
+import com.socrata.http.server.implicits._
+import com.rojoma.json.v3.util.{AutomaticJsonDecodeBuilder, JsonUtil, SimpleHierarchyDecodeBuilder, InternalTag}
+import com.rojoma.json.v3.io.JsonReaderException
+import com.socrata.datacoordinator.service.{BoundedInputStream, ReaderExceededBound}
+import com.socrata.datacoordinator.util.DebugState
+
+object DebugResource extends SodaResource {
+  sealed abstract class DebugCommand
+
+  case class AnalyzeUpsert(threadId: Long) extends DebugCommand
+  object AnalyzeUpsert {
+    implicit val jDecode = AutomaticJsonDecodeBuilder[AnalyzeUpsert]
+  }
+
+  implicit val jCodec = SimpleHierarchyDecodeBuilder[DebugCommand](InternalTag("command")).
+    branch[AnalyzeUpsert]("analyze-upsert").
+    build
+
+  private def doPost(req: HttpRequest): HttpResponse = {
+    val command =
+      try {
+        JsonUtil.readJson[DebugCommand](new InputStreamReader(new BoundedInputStream(req.inputStream, 10240), StandardCharsets.UTF_8)) match {
+          case Right(cmd) => cmd
+          case Left(e) => return BadRequest ~> Content("text/plain", "Malformed debug command: " + e.english)
+        }
+      } catch {
+        case e: ReaderExceededBound =>
+          return RequestEntityTooLarge ~> Content("text/plain", "Body too large")
+        case e: JsonReaderException =>
+          return BadRequest ~> Content("text/plain", "Invalid json")
+      }
+
+    command match {
+      case AnalyzeUpsert(threadId) =>
+        DebugState.requestUpsertExplanation(threadId)
+        OK ~> Content("text/plain", "Request made")
+    }
+  }
+
+  override val post: HttpService = doPost _
+}

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Router.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Router.scala
@@ -28,7 +28,8 @@ case class Router(parseDatasetId: String => Option[DatasetId],
                   secondariesOfDatasetResource: DatasetId => SodaResource,
                   collocationManifestsResource: (Option[String], Option[String]) => SodaResource,
                   resyncResource: (DatasetId, String) => SodaResource,
-                  versionResource: SodaResource) {
+                  versionResource: SodaResource,
+                  debugResource: SodaResource) {
 
   type OptString = Option[String]
 
@@ -90,7 +91,8 @@ case class Router(parseDatasetId: String => Option[DatasetId],
 
       Route("/resync/{DatasetId}/{String}", resyncResource),
 
-      Route("/version", versionResource)
+      Route("/version", versionResource),
+      Route("/debug", debugResource)
     )
   }
 

--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/Service.scala
@@ -287,7 +287,8 @@ class Service(serviceConfig: ServiceConfig,
     datasetSecondaryStatusResource = datasetSecondaryStatusResource,
     secondariesOfDatasetResource = secondariesOfDatasetResource,
     resyncResource = resyncResource,
-    versionResource = VersionResource)
+    versionResource = VersionResource,
+    debugResource = DebugResource)
 
   private val errorHandlingHandler = new ErrorAdapter(router.handler) {
     type Tag = String

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/Sqlizer.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/Sqlizer.scala
@@ -14,7 +14,7 @@ trait ReadDataSqlizer[CT, CV] {
 
   def dataTableName: String
 
-  def findRows(conn: Connection, bySystemId: Boolean, ids: Iterator[CV]): CloseableIterator[Seq[InspectedRow[CV]]]
+  def findRows(conn: Connection, bySystemId: Boolean, ids: Iterator[CV], explain: Boolean = false): CloseableIterator[Seq[InspectedRow[CV]]]
   // When finding rows, it will be performed (and returned) in chunks
   // of this size (note that if you ask for rows that don't exist or
   // provide duplicate IDs, the produced chunks may be smaller than
@@ -38,10 +38,12 @@ trait DataSqlizer[CT, CV] extends ReadDataSqlizer[CT, CV] {
     def insert(row: Row[CV])
   }
 
-  def deleteBatch[T](conn: Connection)(f: Deleter => T): (Long, T)
+  def deleteBatch[T](conn: Connection, explain: Boolean = false)(f: Deleter => T): (Long, T)
   trait Deleter {
     def delete(sid: RowId)
   }
+
+  def doExplain(conn: Connection, sql: String, sqlFiller: PreparedStatement => Unit, idempotent: Boolean): Unit
 
   def prepareSystemIdUpdateStatement: String
   def prepareSystemIdUpdate(stmt: PreparedStatement, sid: RowId, row: Row[CV])

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/StandardRepBasedDataSqlizer.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/loader/sql/StandardRepBasedDataSqlizer.scala
@@ -2,7 +2,7 @@ package com.socrata.datacoordinator
 package truth.loader.sql
 
 import java.io.Closeable
-import java.sql.Connection
+import java.sql.{Connection, PreparedStatement}
 
 import com.rojoma.simplearm.v2._
 
@@ -19,6 +19,9 @@ class StandardRepBasedDataSqlizer[CT, CV](tableName: String,
       val fResult = f(inserter)
       (inserter.stmt.executeBatch().foldLeft(0L)(_+_), fResult)
     }
+  }
+
+  def doExplain(conn: Connection, sql: String, filler: PreparedStatement => Unit, idempotent: Boolean): Unit = {
   }
 
   val bulkInsertStatement =

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/util/DebugState.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/util/DebugState.scala
@@ -1,0 +1,11 @@
+package com.socrata.datacoordinator.util
+
+import java.util.concurrent.ConcurrentHashMap
+
+object DebugState {
+  private val explainUpsert = new ConcurrentHashMap[Long, AnyRef]
+
+  def requestUpsertExplanation(threadId: Long): Unit = explainUpsert.put(threadId, this)
+
+  def isUpsertExplanationRequested(threadId: Long): Boolean = explainUpsert.remove(threadId) ne null
+}


### PR DESCRIPTION
This lets us poke an endpoint to say "hey, the next time this specific
thread starts doing a non-INSERT thing on the database as part of an
upsert operation, log the output of EXPLAINing that query".  INSERTs
are done via COPY which it doesn't really super make sense to EXPLAIN,
but DELETEs, UPDATEs, and the SELECTs to find existing rows all count.