### PR TITLE
Deprecate Jenkins force build parameter

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,7 +29,6 @@ pipeline {
   }
   parameters {
     booleanParam(name: 'RELEASE_CUT', defaultValue: false, description: 'Are we cutting a new release candidate?')
-    booleanParam(name: 'FORCE_BUILD', defaultValue: false, description: 'Force build from latest tag if sbt release needed to be run between cuts')
     string(name: 'AGENT', defaultValue: 'build-worker', description: 'Which build agent to use?')
     string(name: 'BRANCH_SPECIFIER', defaultValue: default_branch_specifier, description: 'Use this branch for building the artifact.')
   }
@@ -89,23 +88,12 @@ pipeline {
       when { expression { stage_cut } }
       steps {
         script {
-          def cutNeeded = false
 
           // get a list of all files changes since the last tag
           files = sh(returnStdout: true, script: "git diff --name-only HEAD `git describe --match \"v*\" --abbrev=0`").trim()
           echo "Files changed:\n${files}"
 
-          if (files == 'version.sbt') {
-            // Build anyway using latest tag - needed if sbt release had to be run between cuts
-            // This parameter will need to be set by the cut job in Jenkins
-            if(params.FORCE_BUILD) {
-              cutNeeded = true
-            }
-            else {
-              echo "No build needed, skipping subsequent steps"
-            }
-          }
-          else {
+          if (files != 'version.sbt') {
             echo 'Running sbt-release'
 
             // The git config setup required for your project prior to running 'sbt release with-defaults' may vary:
@@ -119,27 +107,23 @@ pipeline {
             withEnv([javaopts]) {
               echo sh(returnStdout: true, script: "echo y | sbt \"release with-defaults\"")
             }
-
-            cutNeeded = true
           }
 
-          if(cutNeeded == true) {
-            echo 'Getting release tag'
-            release_tag = sh(returnStdout: true, script: "git describe --abbrev=0 --match \"v*\"").trim()
-            branchSpecifier = "refs/tags/${release_tag}"
-            echo branchSpecifier
+          echo 'Getting release tag'
+          release_tag = sh(returnStdout: true, script: "git describe --abbrev=0 --match \"v*\"").trim()
+          branchSpecifier = "refs/tags/${release_tag}"
+          echo branchSpecifier
 
-            // checkout the tag so we're performing subsequent actions on it
-            sh "git checkout ${branchSpecifier}"
+          // checkout the tag so we're performing subsequent actions on it
+          sh "git checkout ${branchSpecifier}"
 
-            // set the service_sha to the current tag because it might not be the same as env.GIT_COMMIT
-            service_sha = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
+          // set the service_sha to the current tag because it might not be the same as env.GIT_COMMIT
+          service_sha = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
 
-            // set later stages to run since we're cutting
-            stage_build = true
-            stage_dockerize = true
-            stage_deploy = true
-          }
+          // set later stages to run since we're cutting
+          stage_build = true
+          stage_dockerize = true
+          stage_deploy = true
         }
       }
     }


### PR DESCRIPTION
Previously, cut jobs on Jenkins used in the release process were executed only when projects accumulated commits since the prior release. However, the introduction of the Aqua constraint requires releasing all projects each release cycle. Accordingly, the concept of force building-- executing a cut when no changes have happened-- should be default behavior. That is, projects should always build and deploy to RC when the cut job runs.

To address this problem, this commit removes the FORCE_BUILD parameter from this project's Jenkins cut job. As a consequence, the project will build regardless of how many commits follow the previous release, aiding ergonomics.

Relates to [EN-55643](https://socrata.atlassian.net/browse/EN-55643).