### PR TITLE
Do normal secondary playbacks without holding a truth transaction

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/Universe.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/Universe.scala
@@ -50,6 +50,9 @@ trait Commitable {
     */
   def commit()
   def rollback()
+
+  def autoCommit(on: Boolean)
+  def isAutoCommit: Boolean
 }
 
 trait LoggerProvider { this: TypeUniverse =>

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/PostgresUniverse.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/universe/sql/PostgresUniverse.scala
@@ -110,6 +110,7 @@ class PostgresUniverse[ColumnType, ColumnValue](conn: Connection,
 
   private var loggerCache = Map.empty[String, Logger[CT, CV]]
   private var txnStart = DateTime.now()
+  private var isAutoCommit_ = false
 
   private def finish(op: Connection => Unit) {
     loggerCache.values.foreach(_.close())
@@ -130,6 +131,13 @@ class PostgresUniverse[ColumnType, ColumnValue](conn: Connection,
   def rollback() {
     finish(_.rollback())
   }
+
+  def autoCommit(on: Boolean) {
+    conn.setAutoCommit(on)
+    isAutoCommit_ = on
+  }
+
+  def isAutoCommit = isAutoCommit_
 
   def transactionStart = txnStart
 


### PR DESCRIPTION
One of our persistent problems on the truthstores is related to long-running transactions preventing postgresql from vacuuming its transaction log.  In particular, there is a _lot_ of churn on secondary-manifest, both due to updates incrementing latest_data_version when they complete and the keepalive poking `claimed_at` every couple of minutes while a playback is in progress.

This prevents normal (non-resync) secondary playback from holding a transaction the entire time.  I'm hoping this will improve things because updates only touch secondary_manifest right at the very end of their transaction, whereas secondary playback touches it at the beginning _and_ the end, thus (my hypothesis goes) preventing secondary_manifest _in particular_ from being cleaned in a timely fashion.