### PR TITLE
Remove retry counts from secondarylib-feedback

### DIFF
--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackContext.scala
@@ -63,8 +63,6 @@ class FeedbackContext[CT,CV](user: String,
   private def success(current: CookieSchema): Success = {
     Success(currentCookie.copyCurrent(
       current = current,
-      computationRetriesLeft = computationRetryLimit,
-      dataCoordinatorRetriesLeft = dataCoordinatorRetryLimit,
       resync = false,
       errorMessage = None
     ))
@@ -77,8 +75,6 @@ class FeedbackContext[CT,CV](user: String,
   private def replayComputation(reason: String, resync: Boolean): ReplayLater = {
     ReplayLater(reason, { feedbackCookie =>
       feedbackCookie.copyCurrent(
-        computationRetriesLeft = feedbackCookie.current.computationRetriesLeft - 1,
-        dataCoordinatorRetriesLeft = dataCoordinatorRetryLimit,
         resync = resync,
         errorMessage = Some(reason))
     })
@@ -87,8 +83,6 @@ class FeedbackContext[CT,CV](user: String,
   private def replayDataCoordinator(reason: String, resync: Boolean): ReplayLater = {
     ReplayLater(reason, { feedbackCookie =>
       feedbackCookie.copyCurrent(
-        computationRetriesLeft = computationRetryLimit,
-        dataCoordinatorRetriesLeft = feedbackCookie.current.dataCoordinatorRetriesLeft - 1,
         resync = resync,
         errorMessage = Some(reason))
     })

--- a/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackCookie.scala
+++ b/secondarylib-feedback/src/main/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackCookie.scala
@@ -12,14 +12,10 @@ case class DataVersion(underlying: Long)
 case class FeedbackCookie(current: CookieSchema, previous: Option[CookieSchema], errorMessage: Option[String] = None) {
 
   def copyCurrent(current: CookieSchema = this.current,
-                  computationRetriesLeft: Int = this.current.computationRetriesLeft,
-                  dataCoordinatorRetriesLeft: Int = this.current.dataCoordinatorRetriesLeft,
                   resync: Boolean = this.current.resync,
                   errorMessage: Option[String] = this.errorMessage): FeedbackCookie = {
     this.copy(
       current = current.copy(
-        computationRetriesLeft = computationRetriesLeft,
-        dataCoordinatorRetriesLeft = dataCoordinatorRetriesLeft,
         resync = resync),
       errorMessage = errorMessage
     )
@@ -55,8 +51,6 @@ case class CookieSchema(dataVersion: DataVersion,
                         columnIdMap: Map[UserColumnId, ColumnId],
                         strategyMap: Map[UserColumnId, ComputationStrategyInfo],
                         obfuscationKey: Array[Byte],
-                        computationRetriesLeft: Int,
-                        dataCoordinatorRetriesLeft: Int,
                         resync: Boolean) {
 
   override def equals(any: Any): Boolean = {
@@ -68,8 +62,6 @@ case class CookieSchema(dataVersion: DataVersion,
           this.columnIdMap == other.columnIdMap &&
           this.strategyMap == other.strategyMap &&
           java.util.Arrays.equals(this.obfuscationKey, other.obfuscationKey) && // stupid arrays
-          this.computationRetriesLeft == other.computationRetriesLeft &&
-          this.dataCoordinatorRetriesLeft == other.dataCoordinatorRetriesLeft &&
           this.resync == other.resync
       case _ => false
     }
@@ -83,8 +75,6 @@ case class CookieSchema(dataVersion: DataVersion,
     code = code * 41 + (if (columnIdMap == null) 0 else columnIdMap.hashCode)
     code = code * 41 + (if (strategyMap == null) 0 else strategyMap.hashCode)
     code = code * 41 + java.util.Arrays.hashCode(obfuscationKey)
-    code = code * 41 + computationRetriesLeft.hashCode
-    code = code * 41 + dataCoordinatorRetriesLeft.hashCode
     code = code * 41 + resync.hashCode
     code
   }

--- a/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/CookieOperatorTest.scala
+++ b/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/CookieOperatorTest.scala
@@ -44,8 +44,6 @@ class CookieOperatorTest extends FunSuite with Matchers {
     columnIdMap = columns,
     strategyMap = computedColumns,
     obfuscationKey = Array(),
-    computationRetriesLeft = 5,
-    dataCoordinatorRetriesLeft = 5,
     resync = false
   )
 

--- a/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondaryTest.scala
+++ b/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/FeedbackSecondaryTest.scala
@@ -236,7 +236,7 @@ class FeedbackSecondaryTest extends WordSpec with Matchers with MockFactory {
         }
         caught.reason should be("test")
         // for this the data-coordinator retries should be decremented
-        val expectedCookie = FeedbackCookie.encode(TestCookie.v2.get.copyCurrent(dataCoordinatorRetriesLeft = 4, errorMessage = Some("test")))
+        val expectedCookie = FeedbackCookie.encode(TestCookie.v2.get.copyCurrent(errorMessage = Some("test")))
         caught.cookie should be(expectedCookie)
       }
     }

--- a/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/TestData.scala
+++ b/secondarylib-feedback/src/test/scala/com/socrata/datacoordinator/secondary/feedback/TestData.scala
@@ -170,8 +170,6 @@ object TestData {
                    columnIdMap = columnIdMap,
                    strategyMap = strategyMap,
                    obfuscationKey = "magicmagic".getBytes,
-                   computationRetriesLeft = 5,
-                   dataCoordinatorRetriesLeft = 5,
                    resync = false)
 
     // note: we are not always accounting for versions of feedback row data

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -111,7 +111,7 @@ class SecondaryWatcher[CT, CV](universe: => Managed[SecondaryWatcher.UniverseTyp
           manifest(u).markSecondaryDatasetBroken(job, cookie.orElse(job.initialCookie))
         case rlse@ReplayLaterSecondaryException(reason, cookie) =>
           if (job.replayNum < maxReplays) {
-            val replayAfter = Math.min(replayWait.toSeconds * Math.log(job.replayNum + 2), maxReplayWait.toSeconds)
+            val replayAfter = Math.min(replayWait.toSeconds * Math.pow(2, job.replayNum), maxReplayWait.toSeconds)
             log.info("Replay later requested while updating dataset {} in secondary {}, replaying in {}...",
               job.datasetId.asInstanceOf[AnyRef], secondary.storeId, replayAfter.toString, rlse)
             manifest(u).updateReplayInfo(secondary.storeId, job.datasetId, cookie, job.replayNum + 1,


### PR DESCRIPTION
Replay requests are counted DCside and will mark the dataset broken over there automatically, so there's no need to count them on this side.