### PR TITLE
EN-60867: scan for consolidatability from the current position

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/PlaybackToSecondary.scala
@@ -216,7 +216,7 @@ class PlaybackToSecondary[CT, CV](u: PlaybackToSecondary.SuperUniverse[CT, CV],
             // We'll scan over the range of versions, eliminating
             // possibilities for consolidation until there's nothing
             // left, and then play them all back together.
-            (job.startingDataVersion to job.endingDataVersion).iterator.scanLeft((-1L, Consolidatable.all)) { (dvAcc, dv) =>
+            (dataVersion to job.endingDataVersion).iterator.scanLeft((-1L, Consolidatable.all)) { (dvAcc, dv) =>
               val (_, acc) = dvAcc
               using(delogger.delogOnlyTypes(dv)) { it =>
                 (dv, acc.intersect(consolidatable(it.buffered)))


### PR DESCRIPTION
Not the start of the job

Before:
  on every iteration of the loop we look to see if the _job_ starts
  with consolidated versions, then (after the first iteration) we
  discard them and just play back a single version.

Now:
  on every iteration of the loop we look to see if the _remaining range_
  of versions within the job is consolidatable, and if it is, consolidate
  them