### PR TITLE
EN-61797: use release  name as git tag and deploy tag

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -49,6 +49,9 @@ pipeline {
       }
     }
     stage('Build') {
+      when {
+        not { expression { return params.PUBLISH } }
+      }
       steps {
         script {
           // perform any needed modifiers on the build parameters here
@@ -75,7 +78,15 @@ pipeline {
             submoduleCfg: [],
             userRemoteConfigs: [[credentialsId: 'a3959698-3d22-43b9-95b1-1957f93e5a11', url: 'https://github.com/socrata-platform/data-coordinator.git']]
           ])
-          echo sh(returnStdout: true, script: "sbt +publish")
+
+          sbtbuild.setRunITTest(true)
+          sbtbuild.setNoSubproject(true)
+          sbtbuild.setScalaVersion(env.SCALA_VERSION)
+          sbtbuild.setPublish(true)
+          sbtbuild.setBuildType("library")
+
+          echo "Publishing library"
+          sbtbuild.build()
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,7 +40,7 @@ pipeline {
       steps {
         script {
           if (params.RELEASE_DRY_RUN) {
-            echo 'DRY RUN: Skipping release tag creation and possible publish'
+            echo 'DRY RUN: Skipping release tag creation'
           }
           else {
             releaseTag.create(params.RELEASE_NAME)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,11 +5,11 @@
 def service = 'data-coordinator'
 def project_wd = 'coordinator'
 def isPr = env.CHANGE_ID != null;
-def publishStage = false;
 
 // instanciate libraries
 def sbtbuild = new com.socrata.SBTBuild(steps, service, project_wd)
 def dockerize = new com.socrata.Dockerize(steps, service, BUILD_NUMBER)
+def releaseTag = new com.socrata.ReleaseTag(steps, service)
 
 pipeline {
   options {
@@ -18,8 +18,11 @@ pipeline {
   parameters {
     booleanParam(name: 'RELEASE_BUILD', defaultValue: false, description: 'Are we building a release candidate?')
     booleanParam(name: 'RELEASE_DRY_RUN', defaultValue: false, description: 'To test out the release build without creating a new tag.')
+    string(name: 'RELEASE_NAME', defaultValue: '', description: 'For release builds, the release name which is used for the git tag and the deploy tag.')
     string(name: 'AGENT', defaultValue: 'build-worker', description: 'Which build agent to use?')
     string(name: 'BRANCH_SPECIFIER', defaultValue: 'origin/main', description: 'Use this branch for building the artifact.')
+    booleanParam(name: 'PUBLISH', defaultValue: false, description: 'Set to true to manually initiate a publish build - you must also specify PUBLISH_SHA')
+    string(name: 'PUBLISH_SHA', defaultValue: '', description: 'For publish builds, the git commit SHA or branch to build from')
   }
   agent {
     label params.AGENT
@@ -40,37 +43,8 @@ pipeline {
             echo 'DRY RUN: Skipping release tag creation and possible publish'
           }
           else {
-            // get a list of all files changes since the last tag
-            files = sh(returnStdout: true, script: "git diff --name-only HEAD `git describe --match \"v*\" --abbrev=0`").trim()
-            echo "Files changed:\n${files}"
-
-            // the release build process changes the version file, so it will always be changed
-            // if there are other files changed, then increment the version, create a new tag and publish the changes
-            if (files != 'version.sbt') {
-              publishStage = true
-
-              echo 'Running sbt-release'
-
-              // The git config setup required for your project prior to running 'sbt release with-defaults' may vary:
-              sh(returnStdout: true, script: "git config remote.origin.fetch +refs/heads/*:refs/remotes/origin/*")
-              sh(returnStdout: true, script: "git config branch.main.remote origin")
-              sh(returnStdout: true, script: "git config branch.main.merge refs/heads/main")
-
-              // increasing meta space size to avoid build errors during release step
-              javaopts = "JAVA_OPTS=-XX:MaxMetaspaceSize=512m"
-
-              withEnv([javaopts]) {
-                echo sh(returnStdout: true, script: "echo y | sbt \"release with-defaults\"")
-              }
-            }
+            releaseTag.create(params.RELEASE_NAME)
           }
-          echo 'Getting release tag'
-          release_tag = sh(returnStdout: true, script: "git describe --abbrev=0 --match \"v*\"").trim()
-          branchSpecifier = "refs/tags/${release_tag}"
-          echo branchSpecifier
-
-          // checkout the tag so we're performing subsequent actions on it
-          sh "git checkout ${branchSpecifier}"
         }
       }
     }
@@ -90,33 +64,44 @@ pipeline {
     }
     stage('Publish') {
       when {
-        expression { publishStage }
+        expression { return params.PUBLISH }
       }
       steps {
         script {
+          checkout([$class: 'GitSCM',
+            branches: [[name: params.PUBLISH_SHA]],
+            doGenerateSubmoduleConfigurations: false,
+            gitTool: 'Default',
+            submoduleCfg: [],
+            userRemoteConfigs: [[credentialsId: 'a3959698-3d22-43b9-95b1-1957f93e5a11', url: 'https://github.com/socrata-platform/data-coordinator.git']]
+          ])
           echo sh(returnStdout: true, script: "sbt +publish")
         }
       }
     }
     stage('Dockerize') {
       when {
-        not { expression { isPr } }
+        allOf {
+          not { expression { isPr } }
+          not { expression { return params.PUBLISH } }
+        }
       }
       steps {
         script {
-          env.REGISTRY_PUSH = (params.RELEASE_BUILD) ? 'all' : 'internal'
-          env.SERVICE_VERSION = sbtbuild.getServiceVersion()
-          // set the SERVICE_SHA to the current head because it might not be the same as env.GIT_COMMIT
-          env.SERVICE_SHA = sh(returnStdout: true, script: "git rev-parse HEAD").trim()
-          echo "Building docker container..."
-          env.DOCKER_TAG = dockerize.docker_build(env.SERVICE_VERSION, env.SERVICE_SHA, sbtbuild.getDockerPath(), sbtbuild.getDockerArtifact(), env.REGISTRY_PUSH)
+          if (params.RELEASE_BUILD) {
+            env.REGISTRY_PUSH = (params.RELEASE_DRY_RUN) ? 'none' : 'all'
+            env.DOCKER_TAG = dockerize.docker_build_specify_tag_and_push(params.RELEASE_NAME, sbtbuild.getDockerPath(), sbtbuild.getDockerArtifact(), env.REGISTRY_PUSH)
+          } else {
+            env.REGISTRY_PUSH = 'internal'
+            env.DOCKER_TAG = dockerize.docker_build('STAGING', env.GIT_COMMIT, sbtbuild.getDockerPath(), sbtbuild.getDockerArtifact(), env.REGISTRY_PUSH)
+          }
           currentBuild.description = env.DOCKER_TAG
         }
       }
       post {
         success {
           script {
-            if (params.RELEASE_BUILD){
+            if (params.RELEASE_BUILD && !params.RELEASE_DRY_RUN) {
               echo env.DOCKER_TAG // For now, just print the deploy tag in the console output -- later, communicate to release metadata service
             }
           }
@@ -127,6 +112,7 @@ pipeline {
       when {
         not { expression { isPr } }
         not { expression { return params.RELEASE_BUILD } }
+        not { expression { return params.PUBLISH } }
       }
       steps {
         script {

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
+# Data Coordinator
+
 **data-coordinator** is a set of related services, libraries, and scripts that takes SoQL upserts, inserts them to the truth store, watches truth store logs and writes the data to the secondary stores.
 
 ## Projects
 
 * coordinator - contains the REST service for the data coordinator, as well as services for secondary watchers, various scripts including backup
 * coordinatorlib
-    - common utilities and data structures for working with truth store and secondaries, at a lower level
-    - database migrations are in src/main/resources
+  * common utilities and data structures for working with truth store and secondaries, at a lower level
+  * database migrations are in src/main/resources
 * coordinatorlib-soql - en/decoders between SoQL and JSON, CSV, and SQL
 * dummy-secondary - a dummy secondary store implementation for testing only
 * secondarylib - trait for Secondary store
@@ -14,12 +16,16 @@
 
 To run the tests, from the SBT shell:
 
+```sh
     project data-coordinator
     test:test it:test
+```
 
 To run the data coordinator, from the regular Linux/OSX shell prompt:
 
+```sh
     bin/start_dc.sh
+```
 
 The above scripts builds the assembly if its not present and runs the fat jar on the command line, which is much more memory efficient than running it from sbt.  If you need to force a rebuild, simply run `sbt clean` beforehand.
 
@@ -51,10 +57,13 @@ java -Djava.net.preferIPv4Stack=true -Dconfig.file=/etc/pg-secondary.conf -jar s
 ### Migrations
 
 To run migrations in this project from SBT:
+
 ```sh
 sbt -Dconfig.file=/etc/soda2.conf "coordinator/run-main com.socrata.datacoordinator.primary.MigrateSchema migrate"
 ```
+
 Alternatively, to build from scratch and run migrations:
+
 ```sh
 sbt clean
 bin/run_migrations.sh
@@ -62,10 +71,10 @@ bin/run_migrations.sh
 
 To run migrations without building from scratch: `bin/run_migrations.sh`
 
-The command is one of `migrate`, `undo`, `redo`, and there is a second optional paramter for undo for the number of changes to roll back.
+The command is one of `migrate`, `undo`, `redo`, and there is a second optional parameter for undo for the number of changes to roll back.
 
 Running from sbt is recommended in a development environment because
-it ensures you are running the latest migrations without having to build a 
+it ensures you are running the latest migrations without having to build a
 new assembly.
 
 ## Notes
@@ -74,7 +83,7 @@ Below is a copy of the email distributed to engineering when breaking changes we
 
 >Hi All,
 >The secondary architecture has been inverted (thank you @robert.macomber).
->The secondaries (`pg`, `spandex`, `geocoding`) are no longer dynamically 
+>The secondaries (`pg`, `spandex`, `geocoding`) are no longer dynamically
 >loaded as jar files in `secondary-watcher`. But, instead are now their own
 >executable and `secondary-watcher` is now a library that they use.
 
@@ -94,10 +103,17 @@ Below is a copy of the email distributed to engineering when breaking changes we
 
 >   If you want to use the geocoding secondary you will need to add a MapQuest app-token to the config and add it to the
 >      `secondary_stores_config` table in `datacoordinator` (truth).
->       
+>
 >       INSERT INTO secondary_stores_config (store_id, next_run_time, interval_in_seconds, is_feedback_secondary) VALUES( 'geocoding', now(), 5, true);
-       
+
 > - You can now run the secondary stores as their own executable. (See `docs/onramp/start.sh for specifics)
 > - You can delete your `~/secondary-stores` directory :tada:
 
 >Thanks, Alexa
+
+## Publishing
+
+To publish the library:
+
+1. update the version.sbt file, create a PR and merge to main
+1. build the [data-coordinator-branch](https://jenkins-build.socrata.com/job/data-coordinator-branch/) job: check PUBLISH and enter the SHA from the version update commit in PUBLISH_SHA


### PR DESCRIPTION
## Before

- For release builds, we check to see if there are changes (other than the version file) since the last release tag.  If so, we increase the patch version using `sbt release` and publish the changes using `sbt publish`.
- For release builds, the docker tag is in the socrata format (for example `data-coordinator:4.2.13_121_9f7a1a03`) and we push the image to all registries (even for a dry run).
- For main builds, the docker tag is in the socrata format (for example `data-coordinator:4.2.14-SNAPSHOT_115_888897f9`)

## After

- For release builds, we use the RELEASE_NAME parameter (provided by the Release-Build job, which triggers data-coordinator-cut on release builds) for the release tag.  No publishing is done.
- For release builds, the docker tag is in the new format (for example `data-coordinator:P23`) and we push the image to all registries.  For a dry run, we do not push the image to any registries.
- For main builds, the docker tag is in the socrata format with STAGING as the version (for example `data-coordinator:STAGING_115_888897f9`)
- A developer can manually trigger a publish build by setting the PUBLISH boolean parameter to true and entering a PUBLISH_SHA.  This way the new version of the library can be published before the service that uses it is released.
