### PR TITLE
Simplify assembly filename

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,6 +81,7 @@ pipeline {
           sbtbuild.setRunITTest(true)
           sbtbuild.setNoSubproject(true)
           sbtbuild.setScalaVersion(env.SCALA_VERSION)
+          sbtbuild.setSrcJar("coordinator/target/coordinator-assembly.jar")
 
           // build
           echo "Building sbt project..."

--- a/coordinator/build.sbt
+++ b/coordinator/build.sbt
@@ -19,6 +19,10 @@ assembly/test := {}
 
 assembly/mainClass := Some("com.socrata.datacoordinator.Launch")
 
+assembly/assemblyJarName := s"${name.value}-assembly.jar"
+
+assembly/assemblyOutputPath := target.value / (assembly/assemblyJarName).value
+
 // not setting "publish / skip" because soql-postgres-adapter uses this package in its tests.
 
 enablePlugins(BuildInfoPlugin)


### PR DESCRIPTION
* The filename no longer contains the version number
* The file is stored in target instead of target/scala-$version