### PR TITLE
[EN-62246] Fixing collocator lock release bug.

### DIFF
--- a/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
+++ b/coordinator/src/main/scala/com/socrata/datacoordinator/service/collocation/Collocator.scala
@@ -392,8 +392,7 @@ class CoordinatedCollocator(collocationGroup: Set[String],
       lock.release()
     } catch {
       case error: CollocationLockError =>
-        log.error("Unexpected error while releasing collocation lock", error)
-        throw error
+        log.error("Error while releasing collocation lock", error)
     }
   }
 


### PR DESCRIPTION
If lockCollocation() fails, unlockCollocation() is called in finally() block, and it throws because the lock was not acquired to begin with. Rethrowing error in unlockCollocation() could be removed.