### PR TITLE
Allow creating secondary watcher app without needing a typesafe config

### DIFF
--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -502,7 +502,6 @@ object SecondaryWatcherApp {
   type NumWorkers = Int
   def apply
     (dsInfo: Managed[DSInfo], reporter: Managed[MetricsReporter], curator: Managed[CuratorFramework])
-    (secondaryConfig: SecondaryConfig)
     (secondaryWatcherConfig: SecondaryWatcherAppConfig)
     (secondaries: Map[String, (Secondary[SoQLType, SoQLValue], NumWorkers)]
     ): Unit =  {
@@ -540,14 +539,14 @@ object SecondaryWatcherApp {
         NullCache
       )
       val messageProducerExecutor = Executors.newCachedThreadPool()
-      val messageProducer = MessageProducerFromConfig(secondaryWatcherConfig.watcherId, messageProducerExecutor, secondaryConfig.messageProducerConfig)
+      val messageProducer = MessageProducerFromConfig(secondaryWatcherConfig.watcherId, messageProducerExecutor, secondaryWatcherConfig.messageProducerConfig)
       messageProducer.start()
 
-      val w = new SecondaryWatcher(common.universe, secondaryWatcherConfig.watcherId, secondaryConfig.claimTimeout, secondaryConfig.backoffInterval,
-        secondaryConfig.replayWait, secondaryConfig.maxReplayWait, secondaryConfig.maxRetries,
-        secondaryConfig.maxReplays.getOrElse(Integer.MAX_VALUE), common.timingReport,
-        messageProducer, collocationLock, secondaryConfig.collocationLockTimeout)
-      val cm = new SecondaryWatcherClaimManager(dsInfo, secondaryWatcherConfig.watcherId, secondaryConfig.claimTimeout, w.inProgress)
+      val w = new SecondaryWatcher(common.universe, secondaryWatcherConfig.watcherId, secondaryWatcherConfig.claimTimeout, secondaryWatcherConfig.backoffInterval,
+        secondaryWatcherConfig.replayWait, secondaryWatcherConfig.maxReplayWait, secondaryWatcherConfig.maxRetries,
+        secondaryWatcherConfig.maxReplays.getOrElse(Integer.MAX_VALUE), common.timingReport,
+        messageProducer, collocationLock, secondaryWatcherConfig.collocationLockTimeout)
+      val cm = new SecondaryWatcherClaimManager(dsInfo, secondaryWatcherConfig.watcherId, secondaryWatcherConfig.claimTimeout, w.inProgress)
 
       val SIGTERM = new Signal("TERM")
       val SIGINT = new Signal("INT")
@@ -655,6 +654,6 @@ object SecondaryWatcherApp {
       DataSourceFromConfig(config.database),
       MetricsReporter.managed(config.metrics),
       CuratorFromConfig(config.curator)
-    )(config)(config)(secondaries)
+    )(config)(secondaries)
   }
 }

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -629,7 +629,6 @@ object SecondaryWatcherApp {
 
     secondaries.values.foreach { case (secondary, _) => secondary.shutdown()}
     executor.shutdown()
-    
   }
 
 

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -515,7 +515,8 @@ object SecondaryWatcherApp {
       }
     })
 
-    for { dsInfo <- dsInfo
+    for {
+      dsInfo <- dsInfo
       reporter <- reporter
       curator <- curator
     } {

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcher.scala
@@ -536,7 +536,6 @@ object SecondaryWatcherApp {
         secondaryWatcherConfig.tmpdir,
         Duration.fromNanos(1L), // don't care
         Duration.fromNanos(1L), // don't care
-                                //Duration.fromNanos(1L),
         NullCache
       )
       val messageProducerExecutor = Executors.newCachedThreadPool()

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
@@ -14,7 +14,7 @@ import com.socrata.thirdparty.metrics.MetricsOptions
 
 import scala.concurrent.duration._
 
-trait SecondaryConfig {
+trait SecondaryWatcherAppConfig {
   val watcherId: UUID
   val metrics: MetricsOptions
   val collocationLockPath: String
@@ -22,7 +22,7 @@ trait SecondaryConfig {
   val tmpdir: java.io.File
 }
 
-trait SecondaryWatcherAppConfig {
+trait SecondaryConfig {
   val messageProducerConfig: Option[MessageProducerConfig]
   val claimTimeout: FiniteDuration
   val backoffInterval: FiniteDuration

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
@@ -12,24 +12,49 @@ import com.socrata.datacoordinator.common.collocation.CollocationConfig
 import com.socrata.thirdparty.typesafeconfig.ConfigClass
 import com.socrata.thirdparty.metrics.MetricsOptions
 
-class SecondaryWatcherConfig(config: Config, root: String) extends ConfigClass(config, root) {
+import scala.concurrent.duration._
+
+trait SecondaryConfig {
+  val watcherId: UUID
+  val metrics: MetricsOptions
+  val collocationLockPath: String
+  val instance: String
+  val tmpdir: java.io.File
+}
+
+trait SecondaryWatcherAppConfig {
+  val messageProducerConfig: Option[MessageProducerConfig]
+  val claimTimeout: FiniteDuration
+  val backoffInterval: FiniteDuration
+  val replayWait: FiniteDuration
+  val maxReplayWait: FiniteDuration
+  val maxRetries: Int
+  val maxReplays: Option[Int]
+  val collocationLockTimeout: FiniteDuration
+}
+
+class SecondaryWatcherConfig(config: Config, root: String) extends ConfigClass(config, root) with SecondaryWatcherAppConfig with SecondaryConfig {
   val log4j = getRawConfig("log4j")
   val database = getConfig("database", new DataSourceConfig(_, _))
   val curator = getConfig("curator", new CuratorConfig(_, _))
   val discovery = getConfig("service-advertisement", new DiscoveryConfig(_, _))
   val secondaryConfig = getConfig("secondary", new ServiceSecondaryConfig(_, _))
-  val instance = getString("instance")
   val collocation = getConfig("collocation", new CollocationConfig(_, _))
-  val metrics = MetricsOptions(getRawConfig("metrics")) // TODO: make this a ConfigClass
-  val watcherId = UUID.fromString(getString("watcher-id"))
-  val claimTimeout = getDuration("claim-timeout")
-  val maxRetries = getInt("max-retries")
-  val maxReplays = optionally(getInt("max-replays"))
-  val backoffInterval = getDuration("backoff-interval")
-  val maxReplayWait = getDuration("max-replay-wait")
-  val replayWait = getDuration("replay-wait")
-  val tmpdir = new java.io.File(getString("tmpdir")).getAbsoluteFile
-  val messageProducerConfig = optionally(getRawConfig("message-producer")).map { _ =>
-    getConfig("message-producer", new MessageProducerConfig(_, _))
-  }
+
+
+  override val watcherId = UUID.fromString(getString("watcher-id"))
+  override val metrics = MetricsOptions(getRawConfig("metrics")) // TODO: make this a ConfigClass
+  override val collocationLockPath = collocation.lockPath
+  override val instance = getString("instance")
+  override val tmpdir = new java.io.File(getString("tmpdir")).getAbsoluteFile
+
+  override val messageProducerConfig = optionally(getRawConfig("message-producer")).map { _ =>
+    getConfig("message-producer", new MessageProducerConfig(_, _))}
+  override val claimTimeout = getDuration("claim-timeout")
+  override val backoffInterval = getDuration("backoff-interval")
+  override val replayWait = getDuration("replay-wait")
+  override val maxReplayWait = getDuration("max-replay-wait")
+  override val maxRetries = getInt("max-retries")
+  override val maxReplays = optionally(getInt("max-replays"))
+  override val collocationLockTimeout = collocation.lockTimeout
 }

--- a/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
+++ b/secondarylib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryWatcherConfig.scala
@@ -15,46 +15,42 @@ import com.socrata.thirdparty.metrics.MetricsOptions
 import scala.concurrent.duration._
 
 trait SecondaryWatcherAppConfig {
-  val watcherId: UUID
-  val metrics: MetricsOptions
-  val collocationLockPath: String
-  val instance: String
-  val tmpdir: java.io.File
-}
-
-trait SecondaryConfig {
-  val messageProducerConfig: Option[MessageProducerConfig]
-  val claimTimeout: FiniteDuration
   val backoffInterval: FiniteDuration
-  val replayWait: FiniteDuration
-  val maxReplayWait: FiniteDuration
-  val maxRetries: Int
-  val maxReplays: Option[Int]
+  val claimTimeout: FiniteDuration
+  val collocationLockPath: String
   val collocationLockTimeout: FiniteDuration
+  val instance: String
+  val maxReplayWait: FiniteDuration
+  val maxReplays: Option[Int]
+  val maxRetries: Int
+  val messageProducerConfig: Option[MessageProducerConfig]
+  val metrics: MetricsOptions
+  val replayWait: FiniteDuration
+  val tmpdir: java.io.File
+  val watcherId: UUID
+
 }
 
-class SecondaryWatcherConfig(config: Config, root: String) extends ConfigClass(config, root) with SecondaryWatcherAppConfig with SecondaryConfig {
-  val log4j = getRawConfig("log4j")
-  val database = getConfig("database", new DataSourceConfig(_, _))
-  val curator = getConfig("curator", new CuratorConfig(_, _))
-  val discovery = getConfig("service-advertisement", new DiscoveryConfig(_, _))
-  val secondaryConfig = getConfig("secondary", new ServiceSecondaryConfig(_, _))
+class SecondaryWatcherConfig(config: Config, root: String) extends ConfigClass(config, root) with SecondaryWatcherAppConfig {
   val collocation = getConfig("collocation", new CollocationConfig(_, _))
+  val curator = getConfig("curator", new CuratorConfig(_, _))
+  val database = getConfig("database", new DataSourceConfig(_, _))
+  val discovery = getConfig("service-advertisement", new DiscoveryConfig(_, _))
+  val log4j = getRawConfig("log4j")
+  val secondaryConfig = getConfig("secondary", new ServiceSecondaryConfig(_, _))
 
-
-  override val watcherId = UUID.fromString(getString("watcher-id"))
-  override val metrics = MetricsOptions(getRawConfig("metrics")) // TODO: make this a ConfigClass
-  override val collocationLockPath = collocation.lockPath
-  override val instance = getString("instance")
-  override val tmpdir = new java.io.File(getString("tmpdir")).getAbsoluteFile
-
-  override val messageProducerConfig = optionally(getRawConfig("message-producer")).map { _ =>
-    getConfig("message-producer", new MessageProducerConfig(_, _))}
-  override val claimTimeout = getDuration("claim-timeout")
   override val backoffInterval = getDuration("backoff-interval")
-  override val replayWait = getDuration("replay-wait")
-  override val maxReplayWait = getDuration("max-replay-wait")
-  override val maxRetries = getInt("max-retries")
-  override val maxReplays = optionally(getInt("max-replays"))
+  override val claimTimeout = getDuration("claim-timeout")
+  override val collocationLockPath = collocation.lockPath
   override val collocationLockTimeout = collocation.lockTimeout
+  override val instance = getString("instance")
+  override val maxReplayWait = getDuration("max-replay-wait")
+  override val maxReplays = optionally(getInt("max-replays"))
+  override val maxRetries = getInt("max-retries")
+  override val messageProducerConfig = optionally(getRawConfig("message-producer")).map { _ => getConfig("message-producer", new MessageProducerConfig(_, _))}
+  override val metrics = MetricsOptions(getRawConfig("metrics")) // TODO: make this a ConfigClass
+  override val replayWait = getDuration("replay-wait")
+  override val tmpdir = new java.io.File(getString("tmpdir")).getAbsoluteFile
+  override val watcherId = UUID.fromString(getString("watcher-id"))
+
 }


### PR DESCRIPTION
The Redshift secondary does not use typesafe config. It uses the quarkus config system.
This change allows us to construct a secondary watcher app without relying on a typesafe config.