### PR TITLE
New-analyzer rollups and the mover

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/DatabaseAccessors.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/DatabaseAccessors.scala
@@ -444,26 +444,6 @@ object DatasetMutator {
       // while DC would need to handle datasets that live in different truth-stores.
       def validateRollup(ru: RollupInfo): Unit = {
         if(ru.isNewAnalyzer) {
-          import com.socrata.soql.analyzer2._
-          import com.socrata.soql.stdlib.analyzer2.UserParameters
-
-          case class RollupShape(
-            foundTables: FoundTables[UnstagedDataCoordinatorMetaTypes],
-            @AllowMissing("Map.empty") locationSubcolumns: Map[
-              types.DatabaseTableName[UnstagedDataCoordinatorMetaTypes],
-              Map[
-                types.DatabaseColumnName[UnstagedDataCoordinatorMetaTypes],
-                Seq[
-                  Either[JNull, types.DatabaseColumnName[DataCoordinatorMetaTypes]]
-                ]
-              ]
-            ],
-            @AllowMissing("Nil") rewritePasses: Seq[Seq[rewrite.AnyPass]],
-            @AllowMissing("UserParameters.empty") userParameters: UserParameters
-          )
-
-          implicit val decode = AutomaticJsonDecodeBuilder[RollupShape]
-
           JsonUtil.parseJson[RollupShape](ru.soql) match {
             case Right(_) => // ok
             case Left(err) => throw RollupValidationException(ru, err.english)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/RollupShape.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/RollupShape.scala
@@ -1,0 +1,26 @@
+package com.socrata.datacoordinator.truth
+
+import com.rojoma.json.v3.ast.JNull
+import com.rojoma.json.v3.util.{AllowMissing, AutomaticJsonCodecBuilder}
+
+import com.socrata.soql.analyzer2._
+import com.socrata.soql.stdlib.analyzer2.UserParameters
+
+case class RollupShape(
+  foundTables: FoundTables[UnstagedDataCoordinatorMetaTypes],
+  @AllowMissing("Map.empty") locationSubcolumns: Map[
+    types.DatabaseTableName[UnstagedDataCoordinatorMetaTypes],
+    Map[
+      types.DatabaseColumnName[UnstagedDataCoordinatorMetaTypes],
+      Seq[
+        Either[JNull, types.DatabaseColumnName[UnstagedDataCoordinatorMetaTypes]]
+      ]
+    ]
+  ],
+  @AllowMissing("Nil") rewritePasses: Seq[Seq[rewrite.AnyPass]],
+  @AllowMissing("UserParameters.empty") userParameters: UserParameters
+)
+
+object RollupShape {
+  implicit val jCodec = AutomaticJsonCodecBuilder[RollupShape]
+}

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/-impl/BaseDatasetMap.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/-impl/BaseDatasetMap.scala
@@ -2,7 +2,7 @@ package com.socrata.datacoordinator.truth.metadata
 package `-impl`
 
 import com.rojoma.json.v3.ast.JObject
-import com.socrata.datacoordinator.id.{DatasetId, IndexId, IndexName, RollupName}
+import com.socrata.datacoordinator.id.{DatasetInternalName, DatasetId, IndexId, IndexName, RollupName}
 import com.socrata.datacoordinator.util.collection.ColumnIdMap
 import com.socrata.soql.environment.ColumnName
 import org.joda.time.DateTime
@@ -49,6 +49,8 @@ trait BaseDatasetMapReader[CT] {
   /** Returns all rollups for the given dataset copy.
    */
   def rollups(copyInfo: CopyInfo): Iterable[RollupInfo]
+
+  def allRollupsReferencing(internalName: DatasetInternalName): Iterable[RollupInfo]
 
   /** Returns the RollupInfo for the specified rollup.
     */


### PR DESCRIPTION
Not at all sure I like this yet.

At the very least it still needs:
 * an index to make the "find associated rollups" query efficient

But also I'm starting to wonder if NA rollups should refer to internal names at all...