### PR TITLE
Make the "resource name column is unique and not-null" migration pre-…

### DIFF
--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20240501-make-resource-name-required-and-unique.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20240501-make-resource-name-required-and-unique.xml
@@ -3,6 +3,11 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
     <changeSet author="setzer" id="20240501-make-resource-name-required-and-unique" runOnChange="true">
+        <preConditions onFail="MARK_RAN">
+           <sqlCheck expectedResult="0">
+             select count(*) from information_schema.table_constraints where constraint_name = 'dataset_map_resource_name_unique';
+           </sqlCheck>
+        </preConditions>
         <sql><![CDATA[
           alter table dataset_map alter column resource_name set not null, add constraint dataset_map_resource_name_unique unique (resource_name);
         ]]></sql>


### PR DESCRIPTION
…runnable

By having it check to see if one of the constraints it creates already exists, and if so just mark the migration as having already run.