### PR TITLE
EN-67019: Allow unsafeCreateCopy'ing datasets with table modifiers

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
@@ -121,7 +121,8 @@ trait BackupDatasetMap[CT] extends DatasetMapWriter[CT] with `-impl`.BaseDataset
                        copyNumber: Long,
                        lifecycleStage: LifecycleStage,
                        dataVersion: Long,
-                       dataShapeVersion: Long): CopyInfo
+                       dataShapeVersion: Long,
+                       tableModifier: Option[Long]): CopyInfo
 }
 
 case class CopyPair[A <: CopyInfo](oldCopyInfo: A, newCopyInfo: A)


### PR DESCRIPTION
So that the PG secondary can preserve table modifiers across resyncs