### PR TITLE
Add a couple of accessors to the dataset-map

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/-impl/BaseDatasetMap.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/-impl/BaseDatasetMap.scala
@@ -18,6 +18,14 @@ trait BaseDatasetMapReader[CT] {
     * results are guaranteed to be ordered by copy number. */
   def allCopies(datasetInfo: DatasetInfo): Iterable[CopyInfo]
 
+  /** Returns all copies for this dataset, EXCLUDING DISCARDED ONES.  The
+    * results are guaranteed to be ordered by copy number. */
+  def allActiveCopies(datasetInfo: DatasetInfo): Iterable[CopyInfo]
+
+  /** Returns the copy with the most recent data version, even if it's discarded.
+    * This will only return None if a dataset has no copies at all. */
+  def mostRecentlyChangedCopy(datasetInfo: DatasetInfo): Option[CopyInfo]
+
   /** Returns the number of snapshots attached to this dataset. */
   def snapshotCount(datasetInfo: DatasetInfo): Int
 


### PR DESCRIPTION
Certain operations the PG secondary was doing were using `allCopies`, which returns more than it's actually interested in.  The two new accessors are:
 * `allActiveCopies` which returns only non-discarded copies
 * `mostRecentlyChangedCopy` which returns the copy with the highest data version (not necessarily the copy with the highest copy number, e.g., if a working copy is created and discarded then a change happens to the published copy)