### PR TITLE
When marking a dataset to be removed from a secondary, bump next_retry

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/sql/SqlSecondaryManifest.scala
@@ -393,7 +393,8 @@ class SqlSecondaryManifest(conn: Connection) extends SecondaryManifest {
   def markDatasetForDrop(storeId: String, datasetId: DatasetId): Boolean = {
     using(conn.prepareStatement(
     """UPDATE secondary_manifest
-      |SET pending_drop = TRUE
+      |SET pending_drop = TRUE,
+      |    next_retry = clock_timestamp()
       |WHERE store_id = ?
       |  AND dataset_system_id = ?""".stripMargin)) { stmt =>
       stmt.setString(1, storeId)


### PR DESCRIPTION
Otherwise our replication-delay logging will say "this retry was picked up (however long it's been since the dataset was previously updated)"