### PR TITLE
EN-68076: Consistently remove NUL characters from text values

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/soql/sqlreps/TextRep.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/common/soql/sqlreps/TextRep.scala
@@ -52,7 +52,7 @@ class TextRep(val base: String) extends RepUtils with SqlPKableColumnRep[SoQLTyp
 
   def csvifyForInsert(v: SoQLValue) = {
     if(SoQLNull == v) Seq(None)
-    else Seq(Some(v.asInstanceOf[SoQLText].value.replace("\u0000", "")))
+    else Seq(Some(v.asInstanceOf[SoQLText].value))
   }
 
   def prepareInsert(stmt: PreparedStatement, v: SoQLValue, start: Int): Int = {


### PR DESCRIPTION
Before, we were doing this on _inserts_ of specifically _text_ values. Now we do it everywhere a user-provided datum is a text value.