### PR TITLE
EN-68632: Try eagerly locking secondary_manifest rows on mutations

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/metadata/DatasetMap.scala
@@ -32,6 +32,12 @@ trait DatasetMapWriter[CT] extends DatasetMapBase[CT] with `-impl`.BaseDatasetMa
     * @throws DatasetIdInUseByWriterException if some other writer has been used to look up this dataset. */
   def datasetInfo(datasetId: DatasetId, timeout: Duration, semiExclusive: Boolean = false): Option[DatasetInfo]
 
+  /** Advisory: "I'm going to be mutating this dataset, inform the underlying database".
+    * This method exists to (hopefully) prevent deadlock errors by acquiring secondary_manifest
+    * locks early in a transaction, right after loading the dataset.
+    */
+  def replicationLock(datasetInfo: DatasetInfo): Unit
+
   /** Creates a new dataset in the truthstore.
     * @note Does not actually create any tables; this just updates the bookkeeping.
     * @return A `CopyInfo` that refers to an unpublished copy. */

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/sql/PostgresDatabaseMutator.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/truth/sql/PostgresDatabaseMutator.scala
@@ -25,6 +25,7 @@ class PostgresDatabaseMutator[CT, CV](universe: Managed[Universe[CT, CV] with Lo
     final def loadLatestVersionOfDataset(datasetId: DatasetId, lockTimeout: Duration): Option[DatasetCopyContext[CT]] = {
       val map = datasetMap
       map.datasetInfo(datasetId, lockTimeout) map { datasetInfo =>
+        map.replicationLock(datasetInfo)
         val latest = map.latest(datasetInfo)
         val schema = map.schema(latest)
         new DatasetCopyContext(latest, schema)


### PR DESCRIPTION
In order to hopefully avoid deadlocks based on different operations taking locks in different orders.