### PR TITLE
EN-65991: fix publish build issue

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -97,6 +97,7 @@ pipeline {
           lastStage = env.STAGE_NAME
           sbtbuild.setRunITTest(true)
           sbtbuild.setNoSubproject(true)
+          sbtbuild.setPublish(false)
           sbtbuild.setScalaVersion(env.SCALA_VERSION)
           sbtbuild.setSrcJar("coordinator/target/coordinator-assembly.jar")
           sbtbuild.build()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ pipeline {
       when {
         branch 'main'
         expression { publishLibrary }
+        not { expression { params.RELEASE_BUILD } }
       }
       steps {
         script {


### PR DESCRIPTION
After I merged https://github.com/socrata-platform/data-coordinator/pull/462, the main build failed because it tried to publish during the build phase.  This commit fixes the main build issue.
The release build job also failed during the Publish Library phase -- it should not be executing that phase so I've added a `when` condition to exclude it.