### PR TITLE
EN-65991: checkout version tag before publishing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,44 +42,38 @@ pipeline {
   }
   stages {
     stage('Check for Version Change') {
-      /*
       when {
         branch 'main'
         not { expression { params.RELEASE_BUILD } }
       }
-      */
       steps {
         script {
           lastStage = env.STAGE_NAME
          // Checkout to fetch tags because the default checkout does not include tags
           // Fetching the tags without uisng checkout will confuse Jenkins about the git branch
           semVerTag.checkout('main')
-          publishLibrary = haveCertainFilesChanged(filePaths: ['version.sbt'], startingRevision: 'HEAD', endingRevision: 'HEAD~1')
+          publishLibrary = haveCertainFilesChanged(filePaths: ['version.sbt'])
         }
       }
     }
     stage('Publish Library') {
-      /*
       when {
         branch 'main'
         not { expression { params.RELEASE_BUILD } }
         expression { publishLibrary }
       }
-      */
       steps {
         script {
           lastStage = env.STAGE_NAME
           skip = true
           semVerTag.checkoutClosestTag()
           // Build & Publish
-          /*
           sbtbuild.setRunITTest(true)
           sbtbuild.setNoSubproject(true)
           sbtbuild.setScalaVersion(env.SCALA_VERSION)
           sbtbuild.setPublish(true)
           sbtbuild.setBuildType("library")
           sbtbuild.build()
-          */
         }
       }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -42,38 +42,44 @@ pipeline {
   }
   stages {
     stage('Check for Version Change') {
+      /*
       when {
         branch 'main'
         not { expression { params.RELEASE_BUILD } }
       }
+      */
       steps {
         script {
           lastStage = env.STAGE_NAME
          // Checkout to fetch tags because the default checkout does not include tags
           // Fetching the tags without uisng checkout will confuse Jenkins about the git branch
           semVerTag.checkout('main')
-          publishLibrary = haveCertainFilesChanged(filePaths: ['version.sbt'])
+          publishLibrary = haveCertainFilesChanged(filePaths: ['version.sbt'], startingRevision: 'HEAD', endingRevision: 'HEAD~1')
         }
       }
     }
     stage('Publish Library') {
+      /*
       when {
         branch 'main'
         not { expression { params.RELEASE_BUILD } }
         expression { publishLibrary }
       }
+      */
       steps {
         script {
           lastStage = env.STAGE_NAME
           skip = true
           semVerTag.checkoutClosestTag()
           // Build & Publish
+          /*
           sbtbuild.setRunITTest(true)
           sbtbuild.setNoSubproject(true)
           sbtbuild.setScalaVersion(env.SCALA_VERSION)
           sbtbuild.setPublish(true)
           sbtbuild.setBuildType("library")
           sbtbuild.build()
+          */
         }
       }
     }

--- a/README.md
+++ b/README.md
@@ -110,9 +110,11 @@ Below is a copy of the email distributed to engineering when breaking changes we
 
 >Thanks, Alexa
 
-## Publishing
+## Publishing the Library
 
-To publish the library:
+To update the library:
 
-1. Update the version.sbt file, create a PR and merge to main
-1. The Jenkins job for the main branch will build the stages "Check for Version Change" and "Publish Library"
+1. Make a PR, get it approved and merge your commits into main.
+1. From main, make a branch and run `sbt release`. This will create two commits to bump the version and create a git tag for the release version.
+1. Create a PR on the branch, get it approved and merged to main.
+1. Following the merge of the release commits to main, the Jenkins job for the main branch will build the stages "Check for Version Change" and "Publish Library" to publish the library.


### PR DESCRIPTION
This commit updates the workflow for publishing the library.  After my previous PR, the snapshot version was published, which was not intended.  This commit fixes the issue so that the version tagged with the semver is checked out and published.