### PR TITLE
Make secondaries-of-dataset do less databasing

### DIFF
--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryManifest.scala
@@ -45,7 +45,7 @@ trait SecondaryManifest {
   def dropDataset(storeId: String, datasetId: DatasetId): Unit
 
   def datasets(storeId: String): Map[DatasetId, Long]
-  def stores(datasetId: DatasetId): Map[String, (Long, Boolean)]
+  def stores(datasetId: DatasetId): Map[String, SecondaryManifest.StoreInfo]
   def brokenAts(datasetId: DatasetId): Map[String, DateTime]
 
   def allBrokenDatasets: Map[String, Map[DatasetId, BrokenSecondaryRecord]]
@@ -77,6 +77,16 @@ trait SecondaryManifest {
   def performResync(datasetId: DatasetId, storeId: String): Unit
   def lockResync(datasetId: DatasetId, storeId: String, groupName: String): Unit
   def unlockResync(datasetId: DatasetId, storeId: String, groupName: String): Unit
+}
+
+object SecondaryManifest {
+  case class StoreInfo(
+    latestSecondaryDataVersion: Long,
+    pendingDrop: Boolean,
+    brokenAt: Option[DateTime],
+    isFeedback: Boolean,
+    secondaryGroup: Option[String],
+  )
 }
 
 case class NamedSecondary[CT, CV](storeId: String, store: Secondary[CT, CV], groupName: String)

--- a/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryReplicationMessages.scala
+++ b/coordinatorlib/src/main/scala/com/socrata/datacoordinator/secondary/SecondaryReplicationMessages.scala
@@ -34,7 +34,7 @@ class SecondaryReplicationMessages[CT, CV](u: SecondaryReplicationMessages.Super
         storeId => u.secondaryStoresConfig.group(storeId) == Some(groupName)
       }
 
-      if (stores.forall { case (_, (version, _)) => version >= endingDataVersion}) {
+      if (stores.forall { case (_, storeInfo) => storeInfo.latestSecondaryDataVersion >= endingDataVersion}) {
         // it's okay if the others are ahead
         producer.send(GroupReplicationComplete(uid, groupName, stores.keySet,
           newDataVersion = endingDataVersion,

--- a/dataset-mover/src/main/scala/com/socrata/datacoordinator/mover/Main.scala
+++ b/dataset-mover/src/main/scala/com/socrata/datacoordinator/mover/Main.scala
@@ -65,7 +65,7 @@ object Main extends App {
   implicit val executorShutdown = Resource.executorShutdownNoTimeout
 
   def fullyReplicated(datasetId: DatasetId, manifest: SecondaryManifest, targetVersion: Long): Boolean = {
-    manifest.stores(datasetId).values.forall{ case (version: Long, _) => version == targetVersion }
+    manifest.stores(datasetId).values.forall{ case v => v.latestSecondaryDataVersion == targetVersion }
   }
 
   def isPgSecondary(store: String): Boolean =


### PR DESCRIPTION
Before it would:
  1. look up the dataset
  2. find the latest copy
  3. find _all_ copies (and throw away all but the published and unpublished)
  4. look up the data versions in secondary_manifest
  5. figure out which of those secondaries is a feedback secondary
  6. figure out which of those secondaries is broken
  7. look up the group name for each store

Now, 2 and 3 are combined into a single query, and 4-5-6-7 are all combined into one query.  This makes SecondaryManifest#stores slightly more expensive, but since it's only used in the secondaries-of-datasets function and the cross-truth-migrator, it should be a net win.