### PR TITLE
EN-76223: deploy to ECS as well as marathon

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -224,6 +224,14 @@ pipeline {
             tag: env.BUILD_ID,
             environment: env.ENVIRONMENT
           )
+          // While working on migrating from marathon to ECS, we are keeping the tagged images up to date
+          // Once the migration is done, we will remove the marathonDeploy and leave in place this publish which triggers the ECS deployment
+          env.TARGET_DEPLOY_TAG = (env.ENVIRONMENT == 'rc') ? 'rc' : 'latest'
+          dockerize.publish(
+            sourceTag: env.DOCKER_TAG,
+            targetTag: env.TARGET_DEPLOY_TAG,
+            environments: ['internal']
+          )
         }
       }
       post {


### PR DESCRIPTION
While working on migrating from marathon to ECS, we are keeping the tagged images up to date. This commit adds the mechanism for the ECS deployment in addition to the marathon deployment. Once the migration is done, we will remove the marathonDeploy and leave in place the ECS deployment.