### PR TITLE
HF-43 - Fix copy_map purge (#490)

### DIFF
--- a/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20250410-create-purge_copy_map-function-trigger.xml
+++ b/coordinatorlib/src/main/resources/com.socrata.datacoordinator.truth.schema/20250410-create-purge_copy_map-function-trigger.xml
@@ -3,7 +3,7 @@
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
     http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-2.0.xsd">
 
-    <changeSet id="20250410-create-purge_copies-delete-helper-function" author="mtaylor">
+    <changeSet id="20250410-create-purge_copies-delete-helper-function" author="mtaylor" runOnChange="true">
         <sql splitStatements="false">
             CREATE OR REPLACE FUNCTION purge_copies(copy_ids bigint[]) RETURNS VOID AS
             $$
@@ -12,6 +12,7 @@
                 DELETE FROM column_map_geo_modifiers WHERE copy_system_id = ANY (copy_ids);
                 DELETE FROM column_map WHERE copy_system_id = ANY (copy_ids);
                 DELETE FROM index_directive_map WHERE copy_system_id = ANY (copy_ids);
+                DELETE FROM index_map WHERE copy_system_id = ANY (copy_ids);
                 DELETE FROM copy_map_table_modifiers WHERE copy_system_id = ANY (copy_ids);
                 DELETE FROM rollup_map WHERE copy_system_id = ANY (copy_ids);
                 DELETE FROM copy_map WHERE system_id = ANY (copy_ids);


### PR DESCRIPTION
Hot fix to resolve bug that occurs when trying to update a dataset with indices. This has been fixed in Staging via #490 and was introduced in #487.

(cherry picked from commit 9149fa15b473d4dfee12927e543c2a591c38d46d)