### PR TITLE
EN-79175: add secrets report

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,4 @@
-// Set up the libraries
-@Library('socrata-pipeline-library')
+@Library('socrata-pipeline-library@9.0.0')
 
 import com.socrata.ReleaseMetadataService
 def rmsSupportedEnvironment = com.socrata.ReleaseMetadataService.SupportedEnvironment
@@ -38,7 +37,7 @@ pipeline {
   environment {
     SCALA_VERSION = '2.12'
     DEPLOY_PATTERN = "${service}*"
-    WEBHOOK_ID = 'WORKFLOW_IQ'
+    WEBHOOK_ID = 'WORKFLOW_EGRESS_AUTOMATION'
   }
   stages {
     stage('Check for Version Change') {
@@ -91,6 +90,23 @@ pipeline {
             env.CURRENT_RELEASE_NAME = releaseTag.getReleaseName(env.BRANCH_NAME)
             env.HOTFIX_NAME = releaseTag.getHotfixName(env.CURRENT_RELEASE_NAME)
           }
+        }
+      }
+    }
+    stage('Generate Leaked Secrets Report') {
+      when {
+        not { expression { skip } }
+      }
+      steps {
+        script {
+          lastStage = env.STAGE_NAME
+          assert isInstalled('gitleaks'): 'gitleaks is missing.'
+          String secretsReportFileName = 'gitleaks-report.json'
+          String gitleaksCommand = getGitleaksCommand secretsReportFileName
+          assert sh (script: gitleaksCommand, returnStatus: true) == 0: \
+              'Attempt to run gitleaks failed.'
+          echo "Generated report ${secretsReportFileName}."
+          archiveArtifacts artifacts: secretsReportFileName, fingerprint: true
         }
       }
     }


### PR DESCRIPTION
This commit updates the version of the pipelines library used for the Jenkinsfiles. It also adds in a stage for generating the secrets report which is available with the new pipelines version.

The commit also updates the webhook for the team.